### PR TITLE
Fix duplicate interface

### DIFF
--- a/app/api/manga/[id]/chapters/route.ts
+++ b/app/api/manga/[id]/chapters/route.ts
@@ -28,12 +28,6 @@ interface ChaptersResult {
   totalChapters: number;
 }
 
-interface Source {
-  name: string;
-  baseUrl: string;
-  search: (title: string) => Promise<{ titleId: string | null; url: string | null }>;
-  getChapters: (titleId: string, url: string) => Promise<ChaptersResult>;
-}
 
 interface SourceSearchResult {
   source: string;


### PR DESCRIPTION
## Summary
- remove an extra `Source` interface definition in `chapters/route.ts`

## Testing
- `npm run build` *(fails: Unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68414541f1a0832692fce1752de76f8c