### PR TITLE
Remove `any` types from manga APIs and utils

### DIFF
--- a/app/api/manga/[id]/chapter/[chapterId]/route.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route.ts
@@ -48,9 +48,10 @@ const SCRAPING_CONFIGS: Record<string, ScrapingConfig[]> = {
           beforeScroll: async (page: Page) => {
             await page.evaluate(() => {
               // Forcer le chargement des images
-              document.querySelectorAll('img[data-url]').forEach((img: any) => {
-                if (img.dataset.url && !img.src) {
-                  img.src = img.dataset.url;
+              document.querySelectorAll('img[data-url]').forEach(img => {
+                const el = img as HTMLImageElement;
+                if (el.dataset.url && !el.src) {
+                  el.src = el.dataset.url;
                 }
               });
             });
@@ -85,9 +86,10 @@ const SCRAPING_CONFIGS: Record<string, ScrapingConfig[]> = {
               elementsToRemove.forEach(el => el.remove());
               
               // Forcer le chargement des images
-              document.querySelectorAll('img[data-src]').forEach((img: any) => {
-                if (img.dataset.src && !img.src) {
-                  img.src = img.dataset.src;
+              document.querySelectorAll('img[data-src]').forEach(img => {
+                const el = img as HTMLImageElement;
+                if (el.dataset.src && !el.src) {
+                  el.src = el.dataset.src;
                 }
               });
             });
@@ -142,9 +144,10 @@ async function scrapeImages(page: Page, config: ScrapingConfig): Promise<string[
         
         // Attendre et forcer le chargement des images
         await page.evaluate(() => {
-          document.querySelectorAll('img[data-src]').forEach((img: any) => {
-            if (img.dataset.src && !img.src) {
-              img.src = img.dataset.src;
+          document.querySelectorAll('img[data-src]').forEach(img => {
+            const el = img as HTMLImageElement;
+            if (el.dataset.src && !el.src) {
+              el.src = el.dataset.src;
             }
           });
         });

--- a/app/components/FavoritesList.tsx
+++ b/app/components/FavoritesList.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { FavoriteManga, ReadingStatus } from '../types/manga';
 import { Heart, BookOpen, BookX, CheckCircle, Edit3, Trash2, Filter, BarChart2, Search, Calendar, Clock, ArrowUpDown, Star, Info } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
@@ -87,7 +88,7 @@ export default function FavoritesList({
     router.push(`/manga/${mangaId}`);
   };
 
-  const tabs: { status: ReadingStatus; label: string; icon: any }[] = [
+  const tabs: { status: ReadingStatus; label: string; icon: LucideIcon }[] = [
     { status: 'to-read', label: 'À lire', icon: BookOpen },
     { status: 'reading', label: 'En cours', icon: BookX },
     { status: 'completed', label: 'Terminé', icon: CheckCircle },

--- a/app/manga/[id]/page.tsx
+++ b/app/manga/[id]/page.tsx
@@ -178,8 +178,8 @@ function MangaContent() {
               fill
               className="object-cover blur-sm brightness-50"
               priority
-              onError={(e: any) => {
-                e.target.src = DEFAULT_COVER;
+              onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                (e.target as HTMLImageElement).src = DEFAULT_COVER;
               }}
             />
           </div>
@@ -195,8 +195,8 @@ function MangaContent() {
                   fill
                   className="object-cover"
                   priority
-                  onError={(e: any) => {
-                    e.target.src = DEFAULT_COVER;
+                  onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                    (e.target as HTMLImageElement).src = DEFAULT_COVER;
                   }}
                 />
               </div>

--- a/app/types/mangadex.ts
+++ b/app/types/mangadex.ts
@@ -1,0 +1,63 @@
+export interface MangaDexTag {
+  group: string;
+  name: {
+    en: string;
+    fr?: string;
+    [key: string]: string | undefined;
+  };
+}
+
+export interface MangaDexRelationship {
+  id: string;
+  type: string;
+  attributes?: {
+    fileName?: string;
+    name?: string;
+  };
+}
+
+export interface MangaDexManga {
+  id: string;
+  attributes: {
+    title: Record<string, string>;
+    description: Record<string, string>;
+    year?: string;
+    status?: string;
+    originalLanguage?: string;
+    links?: Record<string, string>;
+    tags: MangaDexTag[];
+    availableTranslatedLanguages: string[];
+  };
+  relationships: MangaDexRelationship[];
+}
+
+export interface MangaDexMangaResponse {
+  data: MangaDexManga;
+}
+
+export interface MangaDexChapter {
+  id: string;
+  attributes: {
+    chapter?: string;
+    title?: string;
+    publishAt?: string;
+    translatedLanguage: string;
+  };
+}
+
+export interface MangaDexChaptersResponse {
+  data: MangaDexChapter[];
+}
+
+export interface MangaDexAggregateVolume {
+  chapters: Record<string, { translatedLanguage: string }>;
+}
+
+export interface MangaDexAggregate {
+  volumes?: Record<string, MangaDexAggregateVolume>;
+}
+
+export interface MangaDexSearchResponse {
+  data: MangaDexManga[];
+  total?: number;
+}

--- a/app/utils/cache.ts
+++ b/app/utils/cache.ts
@@ -1,19 +1,19 @@
 import { getRedisClient } from './redisClient';
 
-interface CacheEntry {
-  data: any;
+interface CacheEntry<T> {
+  data: T;
   timestamp: number;
 }
 
-export class Cache {
-  private memoryCache: { [key: string]: CacheEntry } = {};
+export class Cache<T = unknown> {
+  private memoryCache: { [key: string]: CacheEntry<T> } = {};
   private ttl: number;
 
   constructor(ttl: number = 3600000) {
     this.ttl = ttl;
   }
 
-  async set(key: string, data: any): Promise<void> {
+  async set(key: string, data: T): Promise<void> {
     this.memoryCache[key] = { data, timestamp: Date.now() };
     try {
       const client = await getRedisClient();
@@ -23,7 +23,7 @@ export class Cache {
     }
   }
 
-  async get(key: string): Promise<any | null> {
+  async get(key: string): Promise<T | null> {
     const entry = this.memoryCache[key];
     if (entry && Date.now() - entry.timestamp <= this.ttl) {
       return entry.data;
@@ -35,7 +35,7 @@ export class Cache {
       const client = await getRedisClient();
       const val = await client.get(key);
       if (val) {
-        const data = JSON.parse(val);
+        const data = JSON.parse(val) as T;
         this.memoryCache[key] = { data, timestamp: Date.now() };
         return data;
       }

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -15,15 +15,15 @@ export interface LogData {
   chaptersCount?: number;
   status?: number;
   statusText?: string;
-  response?: any;
+  response?: unknown;
   title?: string;
   titles?: string[];
   availableLanguages?: string[];
   source?: string;
   titleId?: string;
   totalChapters?: number;
-  firstChapter?: any;
-  lastChapter?: any;
+  firstChapter?: unknown;
+  lastChapter?: unknown;
   cacheKey?: string;
   executionTime?: number;
   maxRetries?: number;
@@ -33,7 +33,7 @@ export interface LogData {
     hasValidContent: boolean;
     indicators: Record<string, boolean>;
   };
-  params?: any;
+  params?: Record<string, unknown>;
   variants?: string[];
   original?: string;
   totalPages?: number;


### PR DESCRIPTION
## Summary
- add MangaDex API interfaces
- replace `any` with real types across API routes
- make cache generic and update logger interface
- clean components using proper event and icon types

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68415f7a0a1c8326abb3d103664fc17d