### PR TITLE
Use next/image in chapter reader

### DIFF
--- a/app/components/ChapterReader.tsx
+++ b/app/components/ChapterReader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { useInView } from 'react-intersection-observer';
+import Image from 'next/image';
 
 interface ChapterReaderProps {
   pages: string[];
@@ -22,7 +23,7 @@ const ChapterReader: React.FC<ChapterReaderProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const loadedImagesRef = useRef<Set<number>>(new Set());
   const containerRef = useRef<HTMLDivElement>(null);
-  const [ref, inView] = useInView({
+  const [ref] = useInView({
     threshold: 0.5,
     triggerOnce: false
   });
@@ -78,12 +79,15 @@ const ChapterReader: React.FC<ChapterReaderProps> = ({
               className="relative flex justify-center"
               onMouseEnter={() => handlePageChange(index + 1)}
             >
-              <img
+              <Image
                 src={url}
                 alt={`Page ${index + 1}`}
+                width={800}
+                height={1200}
                 className={`max-w-full h-auto ${loadedImagesRef.current.has(index) ? 'opacity-100' : 'opacity-0'} transition-opacity duration-300`}
                 loading="lazy"
                 onLoad={() => handleImageLoad(index)}
+                loader={({ src }) => src}
               />
               {!loadedImagesRef.current.has(index) && (
                 <div className="absolute inset-0 flex items-center justify-center bg-gray-800">


### PR DESCRIPTION
## Summary
- swap `<img>` for Next.js `Image` component in `ChapterReader`
- drop unused imports

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68415f810d84832696605b29195c5594