### PR TITLE
Add useCallback for chapters fetch

### DIFF
--- a/app/components/ChaptersList.tsx
+++ b/app/components/ChaptersList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
 
 interface Chapter {
@@ -49,7 +49,7 @@ export default function ChaptersList({ mangaId }: ChaptersListProps) {
   const [error, setError] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortOption>('newest');
 
-  const fetchChapters = async (page: number) => {
+  const fetchChapters = useCallback(async (page: number) => {
     try {
       setIsLoading(true);
       const url = `/api/manga/${mangaId}/chapters?page=${page}`;
@@ -68,11 +68,11 @@ export default function ChaptersList({ mangaId }: ChaptersListProps) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [mangaId]);
 
   useEffect(() => {
     fetchChapters(1);
-  }, [mangaId]);
+  }, [mangaId, fetchChapters]);
 
   const handlePageChange = (newPage: number) => {
     if (pagination && newPage >= 1 && newPage <= pagination.totalPages) {


### PR DESCRIPTION
## Summary
- memoize chapters fetcher with `useCallback`
- depend on `fetchChapters` in effect

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68415f82e234832683bd3106e8b7ffce