### PR TITLE
fix(api): remove merge markers and tidy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Timestamped error logs for easier debugging.
 - Unified API response with `pageCount` and `pages` array.
 - Stronger type safety with explicit interfaces replacing `any`.
+- Logger interface cleaned up to remove duplicate fields.
 
 - Chapter images fetched via the MangaDex API with cached results (fallback to scraping).
 

--- a/app/api/manga/[id]/chapter/[chapterId]/route.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route.ts
@@ -3,26 +3,6 @@ import puppeteer, { Page, Browser } from 'puppeteer';
 import { Cache } from '@/app/utils/cache';
 
 
-interface ChapterCacheData {
-  id: string;
-  mangaId: string;
-  title: string;
-  chapter: string | null;
-  volume: string | null;
-  pageCount: number;
-  pages: string[];
-  language: string;
-  scrapingMethod: string | null;
-  mangaTitle: string;
-  publishAt: string;
-  readableAt: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-// Cache pour les images de chapitres (1 heure)
-const cache = new Cache<ChapterCacheData>(3600000);
-=======
 // Préférer l'API MangaDex puis basculer sur Puppeteer en secours
 // Cache pour les images de chapitres (1 heure)
 const cache = new Cache<ChapterResult>(3600000);


### PR DESCRIPTION
## Summary
- clean merge conflict markers in chapter route
- document logger cleanup

## Testing
- `npm run lint`
- `npm audit --omit=dev`
- `npx --yes lighthouse https://example.com --quiet --chrome-flags="--headless"` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_6841fd4b28f0832682476b3687bddf37