### PR TITLE
feat(reader): scroll-controlled header

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Unified API response with `pageCount` and `pages` array.
 - Stronger type safety with explicit interfaces replacing `any`.
 - Logger interface cleaned up to remove duplicate fields.
+- Header visibility responds to scroll direction while reading.
 
 - Chapter images fetched via the MangaDex API with cached results (fallback to scraping).
 


### PR DESCRIPTION
## Summary
- show/hide chapter header based on scroll direction
- shorten header padding
- document scroll-responsive header in README

## Testing
- `npm run lint`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_68420759e4548326ae4fcd656e24df2f