### PR TITLE
Reuse browser instance for chapter scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Header visibility responds to scroll direction while reading.
 
 - Chapter images fetched via the MangaDex API with cached results (fallback to scraping).
+- Browser instance reused across chapter searches for faster scraping.
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.

--- a/app/components/ChapterReader.tsx
+++ b/app/components/ChapterReader.tsx
@@ -6,19 +6,17 @@ import { ChevronUp } from 'lucide-react'
 
 interface ChapterReaderProps {
   pages: string[]
-  title: string
   chapter: string
   mangaTitle: string
   onPageChange?: (page: number) => void
 }
 
-const ChapterReader: React.FC<ChapterReaderProps> = ({ pages, title, chapter, mangaTitle, onPageChange }) => {
+const ChapterReader: React.FC<ChapterReaderProps> = ({ pages, chapter, mangaTitle, onPageChange }) => {
   const [currentPage, setCurrentPage] = useState(1)
   const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set())
   const [imageErrors, setImageErrors] = useState<Set<number>>(new Set())
   const [isUIVisible, setIsUIVisible] = useState(true)
   const lastScrollY = useRef(0)
-  const totalPages = pages.length
   const containerRef = useRef<HTMLDivElement>(null)
 
   const handleScroll = useCallback(() => {

--- a/app/manga/[id]/chapter/[chapterId]/page.tsx
+++ b/app/manga/[id]/chapter/[chapterId]/page.tsx
@@ -272,9 +272,8 @@ function ChapterReaderContent() {
 
       {/* Contenu principal avec le reader */}
       <div className={`${showHeader ? 'pt-16' : 'pt-0'} transition-all duration-300`}>
-        <ChapterReader 
+        <ChapterReader
           pages={chapterData.pages}
-          title={chapterData.title || ''}
           chapter={chapterData.chapter}
           mangaTitle={chapterData.mangaTitle}
           onPageChange={(page) => {


### PR DESCRIPTION
## Summary
- share a single Puppeteer browser in `chapters` API route
- close the shared browser on process exit
- update scraping sources to get browser from the new helper
- fix lint issues and remove unused props
- document browser reuse in README

## Testing
- `npm run lint`
- `npx vitest run`
- `npm audit --json`

------
https://chatgpt.com/codex/tasks/task_e_684217ca738c8326ba5853db3e29f0dc