### PR TITLE
Improve chapter reader image loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Features
 
-- Chapter reader with lazy-loaded images.
+- Chapter reader with lazy-loaded images, blurred placeholders and preloaded next pages.
 - Improved scraping logic using custom lazy-load steps.
 - Fixed image aspect ratio warnings using explicit style attributes.
 - Hook `useChapterNavigation` to manage chapter navigation.


### PR DESCRIPTION
## Summary
- enhance `ChapterReader` image placeholders with blurred 1×1 pixel
- preload the next page image when a page becomes active
- update README features

## Testing
- `npm run lint`
- `npx vitest run`
- `npm audit --foreground-scripts`


------
https://chatgpt.com/codex/tasks/task_e_6842938ccb6083268d18956a558da9dc