### PR TITLE
Refactor Puppeteer launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Chapter images fetched via the MangaDex API with cached results (fallback to scraping).
 - Manga details cached for an hour to minimize API calls.
 - Browser instance reused across chapter searches for faster scraping.
+- Common Puppeteer launch arguments moved to a `launchBrowser` utility.
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.

--- a/app/api/manga/[id]/chapter/[chapterId]/route.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import puppeteer, { Page, Browser } from 'puppeteer';
+import type { Page, Browser } from 'puppeteer';
+import { launchBrowser } from '@/app/utils/launchBrowser';
 import { Cache } from '@/app/utils/cache';
 
 
@@ -12,15 +13,9 @@ let browserPromise: Promise<Browser> | null = null;
 
 async function getBrowser(): Promise<Browser> {
   if (!browserPromise) {
-    browserPromise = puppeteer.launch({
+    browserPromise = launchBrowser({
       headless: true,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-        '--disable-web-security',
-        '--disable-features=VizDisplayCompositor',
-      ],
+      args: ['--disable-features=VizDisplayCompositor'],
     });
   }
   return browserPromise;

--- a/app/api/manga/[id]/chapters/route.ts
+++ b/app/api/manga/[id]/chapters/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import puppeteer from 'puppeteer';
+import { launchBrowser } from '@/app/utils/launchBrowser';
 import type { Page, Browser } from 'puppeteer';
 import { Cache } from '@/app/utils/cache';
 import { logger } from '@/app/utils/logger';
@@ -64,16 +64,12 @@ let browserPromise: Promise<Browser> | null = null;
 
 async function getBrowser(): Promise<Browser> {
   if (!browserPromise) {
-    browserPromise = puppeteer.launch({
+    browserPromise = launchBrowser({
       headless: false,
       args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
         '--disable-accelerated-2d-canvas',
         '--disable-gpu',
         '--window-size=1920x1080',
-        '--disable-web-security',
         '--disable-features=IsolateOrigins,site-per-process',
         '--disable-blink-features=AutomationControlled'
       ],

--- a/app/utils/launchBrowser.ts
+++ b/app/utils/launchBrowser.ts
@@ -1,0 +1,22 @@
+import puppeteer, { Browser, LaunchOptions } from 'puppeteer';
+
+/**
+ * Launches a Puppeteer browser with common arguments.
+ *
+ * The `--no-sandbox` flag is required because the server runs as root in
+ * certain container environments where Chromium's sandbox cannot start.
+ * If your deployment supports the sandbox, you can remove this flag.
+ */
+export function launchBrowser(options: LaunchOptions = {}): Promise<Browser> {
+  const commonArgs = [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-web-security',
+  ];
+  return puppeteer.launch({
+    headless: true,
+    ...options,
+    args: options.args ? [...commonArgs, ...options.args] : commonArgs,
+  });
+}


### PR DESCRIPTION
## Summary
- centralize Puppeteer launch options with `launchBrowser`
- use the helper in chapter routes
- document the new helper

## Testing
- `npm run lint`
- `npx vitest run`
- `npm audit --omit=dev`

------
https://chatgpt.com/codex/tasks/task_e_6842938e57c8832684a8772c513f93e3