### PR TITLE
fix(reader): preload upcoming images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Features
 
-- Chapter reader with lazy-loaded images, blurred placeholders and preloaded next pages.
+- Chapter reader with lazy-loaded images, blurred placeholders and preloads up to five upcoming pages.
 - Improved scraping logic using custom lazy-load steps.
 - Fixed image aspect ratio warnings using explicit style attributes.
 - Blur placeholder ensures images reserve their space and fade in smoothly.


### PR DESCRIPTION
## Summary
- preload up to five upcoming chapter images
- document new image preload behavior

## Testing
- `npm run lint`
- `npx vitest run`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_6842989aa6688326a7cd6362ec690f69