### PR TITLE
Fix reader image layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 - Chapter reader with lazy-loaded images, blurred placeholders and preloads up to five upcoming pages.
 - Improved scraping logic using custom lazy-load steps.
-- Fixed image aspect ratio warnings using explicit style attributes.
+- Fixed image aspect ratio warnings using Next.js `fill` layout for responsive images.
 - Blur placeholder ensures images reserve their space and fade in smoothly.
 - Hook `useChapterNavigation` to manage chapter navigation.
 - Progress indicator showing loaded pages vs total while reading.

--- a/app/components/ChapterReader.tsx
+++ b/app/components/ChapterReader.tsx
@@ -120,9 +120,9 @@ const ChapterReader: React.FC<ChapterReaderProps> = ({ pages, chapter, mangaTitl
                 <Image
                   src={url}
                   alt={`Page ${index + 1} - ${mangaTitle} - Chapitre ${chapter}`}
-                  width={800} // Adjust as per your design needs
-                  height={1200} // Adjust as per your design needs
-                  className={`max-w-full h-auto ${isLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity duration-500`}
+                  fill
+                  sizes="100vw"
+                  className={`object-contain ${isLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity duration-500`}
                   onLoad={() => handleImageLoad(index)}
                   onError={() => handleImageError(index)}
                   loading={index < 2 ? 'eager' : 'lazy'} // Conditionally set loading based on priority


### PR DESCRIPTION
## Summary
- improve image layout in `ChapterReader` by using `next/image` fill mode
- update documentation with new responsive image approach

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68429cfa46b483269a58b6ffa4f669ce