### PR TITLE
Add retry logic to MangaDex API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.
+- MangaDex API requests automatically retry up to three times on network errors.
 
 
 ## Usage

--- a/app/api/manga/[id]/chapter/[chapterId]/route.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { Page, Browser } from 'puppeteer';
 import { launchBrowser } from '@/app/utils/launchBrowser';
 import { Cache } from '@/app/utils/cache';
+import { retry } from '@/app/utils/retry';
 
 
 // Préférer l'API MangaDex puis basculer sur Puppeteer en secours
@@ -25,8 +26,13 @@ async function getMangaDexChapterImages(
   chapterId: string,
 ): Promise<string[]> {
   try {
-    const res = await fetch(
-      `https://api.mangadex.org/at-home/server/${encodeURIComponent(chapterId)}`,
+    const res = await retry(
+      () =>
+        fetch(
+          `https://api.mangadex.org/at-home/server/${encodeURIComponent(chapterId)}`,
+        ),
+      3,
+      1000,
     );
     if (!res.ok) {
       console.log(
@@ -387,8 +393,13 @@ export async function GET(
     console.log(`🔍 Lecture du chapitre ${chapterId}`);
 
     // Récupérer les infos du manga depuis l'API MangaDex
-    const mangaResponse = await fetch(
-      `https://api.mangadex.org/manga/${encodeURIComponent(mangaId)}?includes[]=author&includes[]=artist&includes[]=cover_art`,
+    const mangaResponse = await retry(
+      () =>
+        fetch(
+          `https://api.mangadex.org/manga/${encodeURIComponent(mangaId)}?includes[]=author&includes[]=artist&includes[]=cover_art`,
+        ),
+      3,
+      1000,
     );
     
     if (!mangaResponse.ok) {
@@ -399,8 +410,13 @@ export async function GET(
     const manga = mangaData.data;
     
     // Récupérer les infos du chapitre
-    const chapterResponse = await fetch(
-      `https://api.mangadex.org/chapter/${encodeURIComponent(chapterId)}?includes[]=scanlation_group&includes[]=user`,
+    const chapterResponse = await retry(
+      () =>
+        fetch(
+          `https://api.mangadex.org/chapter/${encodeURIComponent(chapterId)}?includes[]=scanlation_group&includes[]=user`,
+        ),
+      3,
+      1000,
     );
     
     if (!chapterResponse.ok) {

--- a/app/api/manga/[id]/route.ts
+++ b/app/api/manga/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Cache } from '@/app/utils/cache';
+import { retry } from '@/app/utils/retry';
 import type {
   MangaDexAggregate,
   MangaDexChaptersResponse,
@@ -90,9 +91,9 @@ export async function GET(
 
     // Récupérer les données du manga
     const [mangaResponse, chaptersResponse, aggregateResponse] = await Promise.all([
-      fetch(mangaUrl),
-      fetch(chaptersUrl),
-      fetch(aggregateUrl)
+      retry(() => fetch(mangaUrl), 3, 1000),
+      retry(() => fetch(chaptersUrl), 3, 1000),
+      retry(() => fetch(aggregateUrl), 3, 1000)
     ]);
 
     if (!mangaResponse.ok) {


### PR DESCRIPTION
## Summary
- wrap main MangaDex search fetch in a retry helper
- retry chapter feed requests from `/api/scraper`
- add the same retry logic to chapter and manga detail endpoints
- document the retry feature in README

## Testing
- `npm run lint`
- `npm audit`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842a02f8d208326a8f1398750091676