### PR TITLE
Replace console.error with logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Progress indicator showing loaded pages vs total while reading.
 - Asynchronous API routes with proper parameter handling.
 - Timestamped error logs for easier debugging.
+- Consistent `logger.log('error')` calls replace `console.error` for structured logging.
 - Unified API response with `pageCount` and `pages` array.
 - Stronger type safety with explicit interfaces replacing `any`.
 - Logger interface cleaned up to remove duplicate fields.

--- a/app/api/manga/[id]/chapter/[chapterId]/route-old.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route-old.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { Page } from 'puppeteer';
 import puppeteer from 'puppeteer';
+import { logger } from '@/app/utils/logger';
 
 // Fonction pour récupérer les vraies images depuis MangaDex
 async function getMangaDexChapterImages(chapterId: string): Promise<string[]> {
@@ -236,7 +237,7 @@ async function scrapeImages(page: Page, config: ScrapingConfig): Promise<string[
     }
 
   } catch (error) {
-    console.error('❌ Erreur lors du scraping:', error);
+    logger.log('error', 'scraping error', { error: String(error) });
     return [];
   }
 }
@@ -308,7 +309,7 @@ async function scrapeWebtoons(page: Page): Promise<string[]> {
     console.log(`✅ Webtoons: ${images.size} images trouvées`);
     
   } catch (error) {
-    console.error('❌ Erreur scraping Webtoons:', error);
+    logger.log('error', 'webtoons scraping error', { error: String(error) });
   }
   
   return Array.from(images);
@@ -383,7 +384,7 @@ async function scrapeGeneric(page: Page, config: ScrapingConfig): Promise<string
     }
     
   } catch (error) {
-    console.error('❌ Erreur scraping générique:', error);
+    logger.log('error', 'generic scraping error', { error: String(error) });
   }
   
   return Array.from(images);
@@ -523,7 +524,9 @@ export async function GET(
             break;
           }
         } catch (error) {
-          console.error(`❌ Échec avec ${config.name}:`, error);
+          logger.log('error', `scraping attempt failed for ${config.name}`, {
+            error: String(error)
+          });
           continue;
         }
       }
@@ -600,7 +603,7 @@ export async function GET(
     }
 
   } catch (error) {
-    console.error('❌ Erreur:', error);
+    logger.log('error', 'route error', { error: String(error) });
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Erreur inconnue' },
       { status: 500 }

--- a/app/api/manga/[id]/route.ts
+++ b/app/api/manga/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Cache } from '@/app/utils/cache';
+import { logger } from '@/app/utils/logger';
 import type {
   MangaDexAggregate,
   MangaDexChaptersResponse,
@@ -189,7 +190,10 @@ export async function GET(
     await mangaCache.set(mangaId, formattedManga);
     return NextResponse.json(formattedManga);
   } catch (error) {
-    console.error('Erreur lors de la récupération des détails du manga:', error);
+    logger.log('error', 'failed to fetch manga details', {
+      error: String(error),
+      mangaId
+    });
     return NextResponse.json(
       { error: 'Erreur lors de la récupération des détails du manga' },
       { status: 500 }

--- a/app/api/scraping-test/route.ts
+++ b/app/api/scraping-test/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { diagnoseScrapingSelectors } from '../../utils/scraping-diagnostics';
+import { logger } from '../../utils/logger';
 
 export async function POST(request: NextRequest) {
   try {
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(response);
 
   } catch (error) {
-    console.error('❌ Erreur lors du diagnostic:', error);
+    logger.log('error', 'diagnostic api error', { error: String(error) });
     return NextResponse.json(
       { error: 'Erreur lors du diagnostic', details: String(error) },
       { status: 500 }

--- a/app/components/ChapterReader.tsx
+++ b/app/components/ChapterReader.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import Image from 'next/image'
 import { ChevronUp } from 'lucide-react'
+import { logger } from '@/app/utils/logger'
 
 interface ChapterReaderProps {
   pages: string[]
@@ -71,7 +72,7 @@ const ChapterReader: React.FC<ChapterReaderProps> = ({ pages, chapter, mangaTitl
   }
 
   const handleImageError = (index: number) => {
-    console.error(`Erreur de chargement de l'image ${index + 1}`)
+    logger.log('error', `Image ${index + 1} failed to load`, { index })
     setImageErrors(prev => new Set(prev.add(index)))
   }
 

--- a/app/manga/[id]/chapter/[chapterId]/page.tsx
+++ b/app/manga/[id]/chapter/[chapterId]/page.tsx
@@ -7,6 +7,7 @@ import { retry } from '@/app/utils/retry';
 import { ArrowLeft, ChevronLeft, ChevronRight, List, Settings } from 'lucide-react';
 import ChapterReader from '@/app/components/ChapterReader';
 import { useChapterNavigation, Chapter as NavChapter } from '@/app/hooks/useChapterNavigation';
+import { logger } from '@/app/utils/logger';
 
 interface ChapterData {
   title: string;
@@ -81,7 +82,7 @@ function ChapterReaderContent() {
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Une erreur est survenue';
-        console.error(`[${new Date().toISOString()}] ${message}`);
+        logger.log('error', message, { mangaId, chapterId });
         setError(message);
         setChapterData(null);
       } finally {

--- a/app/manga/[id]/page.tsx
+++ b/app/manga/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useFavorites } from '@/app/hooks/useFavorites';
 import Layout from '@/app/components/Layout';
 import { extractShortSynopsis } from '@/app/components/SynopsisContent';
 import ChaptersList from '@/app/components/ChaptersList';
+import { logger } from '@/app/utils/logger';
 
 const DEFAULT_COVER = '/images/default-cover.jpg';
 
@@ -56,7 +57,7 @@ function MangaContent() {
             setFirstChapterId(chaptersData.chapters[0].id);
           }
         } catch (error) {
-          console.error('Erreur lors de la récupération des chapitres:', error);
+          logger.log('error', 'fetch chapters failed', { error: String(error) });
         }
       } catch (error) {
         setError(error instanceof Error ? error.message : 'Une erreur est survenue');
@@ -84,7 +85,7 @@ function MangaContent() {
       setIsInFavorites(!isInFavorites);
     } catch (error) {
       // Afficher une notification d'erreur si nécessaire
-      console.error('Erreur lors de la gestion des favoris:', error);
+      logger.log('error', 'favorites management failed', { error: String(error) });
     }
   };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import ClientOnly from './components/ClientOnly';
 import { scrapeManga } from './services/scraping.service';
 import { useFavorites } from './hooks/useFavorites';
 import { BookmarkPlus } from 'lucide-react';
+import { logger } from '@/app/utils/logger';
 
 const MAX_HISTORY_ITEMS = 5;
 
@@ -50,7 +51,7 @@ export default function Home() {
         return newHistory;
       });
     } catch (error) {
-      console.error('Erreur:', error);
+      logger.log('error', 'search failed', { error: String(error), query });
     } finally {
       setLoading(false);
     }

--- a/app/scripts/test-scraping.ts
+++ b/app/scripts/test-scraping.ts
@@ -1,4 +1,5 @@
 import { batchDiagnose, generateOptimalSelectors, type DiagnosticResult } from '../utils/scraping-diagnostics';
+import { logger } from '../utils/logger';
 
 async function testScrapingConfigs() {
   console.log('🔍 Diagnostic des configurations de scraping...\n');
@@ -73,7 +74,7 @@ async function testScrapingConfigs() {
     generateUpdatedConfig(results);
 
   } catch (error) {
-    console.error('❌ Erreur lors du diagnostic:', error);
+    logger.log('error', 'diagnostic run error', { error: String(error) });
   }
 }
 
@@ -116,7 +117,11 @@ function generateUpdatedConfig(results: DiagnosticTestResult[]) {
 
 // Execution si lancé directement
 if (require.main === module) {
-  testScrapingConfigs().catch(console.error);
+  testScrapingConfigs().catch(error =>
+    logger.log('error', 'Unhandled error in testScrapingConfigs', {
+      error: String(error)
+    })
+  );
 }
 
 export { testScrapingConfigs };

--- a/app/utils/cache.ts
+++ b/app/utils/cache.ts
@@ -1,4 +1,5 @@
 import { getRedisClient } from './redisClient';
+import { logger } from './logger';
 
 interface CacheEntry<T> {
   data: T;
@@ -19,7 +20,7 @@ export class Cache<T = unknown> {
       const client = await getRedisClient();
       await client.setEx(key, Math.floor(this.ttl / 1000), JSON.stringify(data));
     } catch (err) {
-      console.error('Redis set error', err);
+      logger.log('error', 'Redis set error', { error: String(err), key });
     }
   }
 
@@ -40,7 +41,7 @@ export class Cache<T = unknown> {
         return data;
       }
     } catch (err) {
-      console.error('Redis get error', err);
+      logger.log('error', 'Redis get error', { error: String(err), key });
     }
     return null;
   }

--- a/app/utils/redisClient.ts
+++ b/app/utils/redisClient.ts
@@ -1,4 +1,5 @@
 import { createClient, RedisClientType } from 'redis';
+import { logger } from './logger';
 
 const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
 
@@ -14,8 +15,7 @@ export async function getRedisClient(): Promise<RedisClientType> {
     });
     
     client.on('error', err => {
-      console.error('Redis Client Error:', err);
-      console.error('Redis URL:', redisUrl);
+      logger.log('error', 'Redis client error', { error: String(err), redisUrl });
     });
     
     client.on('connect', () => {
@@ -35,7 +35,7 @@ export async function testRedisConnection(): Promise<boolean> {
     console.log('Redis connection test: SUCCESS');
     return true;
   } catch (error) {
-    console.error('Redis connection test: FAILED', error);
+    logger.log('error', 'Redis connection test failed', { error: String(error) });
     return false;
   }
 }

--- a/app/utils/scraping-diagnostics.ts
+++ b/app/utils/scraping-diagnostics.ts
@@ -1,4 +1,5 @@
 import puppeteer from 'puppeteer';
+import { logger } from './logger';
 
 export interface DiagnosticResult {
   url: string;
@@ -230,7 +231,7 @@ export async function batchDiagnose(testCases: Array<{
       // Pause entre les requêtes
       await new Promise(resolve => setTimeout(resolve, 2000));
     } catch (error) {
-      console.error(`Erreur lors du diagnostic de ${testCase.name}:`, error);
+      logger.log('error', `diagnostic failed for ${testCase.name}`, { error: String(error), url: testCase.url });
       results.push({
         url: testCase.url,
         name: testCase.name,

--- a/app/utils/site-analyzer.ts
+++ b/app/utils/site-analyzer.ts
@@ -1,4 +1,5 @@
 import { chromium, Browser } from 'playwright';
+import { logger } from './logger';
 
 interface ContainerInfo {
   selector: string;
@@ -101,7 +102,7 @@ export class SiteAnalyzer {
       return analysis;
 
     } catch (error) {
-      console.error('❌ Erreur lors de l\'analyse Webtoons:', error);
+      logger.log('error', 'Webtoons analysis failed', { error: String(error) });
       return null;
     } finally {
       await page.close();
@@ -170,7 +171,7 @@ export class SiteAnalyzer {
       return analysis;
 
     } catch (error) {
-      console.error('❌ Erreur lors de l\'analyse Reaper-Scans:', error);
+      logger.log('error', 'Reaper-Scans analysis failed', { error: String(error) });
       return null;
     } finally {
       await page.close();
@@ -222,7 +223,7 @@ async function main() {
     }
     
   } catch (error) {
-    console.error('❌ Erreur générale:', error);
+    logger.log('error', 'site analyzer error', { error: String(error) });
   } finally {
     await analyzer.close();
   }


### PR DESCRIPTION
## Summary
- switch to structured logger in all modules
- document error logging via `logger.log('error')`

## Testing
- `npm run lint`
- `npm audit --json`

------
https://chatgpt.com/codex/tasks/task_e_6842a030de5883269989ea3e8906e92f