### PR TITLE
feat(cache): prune expired entries automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.
+- In-memory cache automatically prunes expired entries to limit memory usage.
 
 
 ## Usage

--- a/app/utils/cache.ts
+++ b/app/utils/cache.ts
@@ -13,7 +13,17 @@ export class Cache<T = unknown> {
     this.ttl = ttl;
   }
 
+  private pruneExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of Object.entries(this.memoryCache)) {
+      if (now - entry.timestamp > this.ttl) {
+        delete this.memoryCache[key];
+      }
+    }
+  }
+
   async set(key: string, data: T): Promise<void> {
+    this.pruneExpired();
     this.memoryCache[key] = { data, timestamp: Date.now() };
     try {
       const client = await getRedisClient();
@@ -24,6 +34,7 @@ export class Cache<T = unknown> {
   }
 
   async get(key: string): Promise<T | null> {
+    this.pruneExpired();
     const entry = this.memoryCache[key];
     if (entry && Date.now() - entry.timestamp <= this.ttl) {
       return entry.data;


### PR DESCRIPTION
## Summary
- extend `Cache` with a `pruneExpired` method
- call `pruneExpired` in `set` and `get`
- document cache pruning in README

## Testing
- `npm run lint`
- `npm audit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6842a031564c83269232765ab1957dd3