### PR TITLE
Fix hydration mismatch from browser-only state

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Stronger type safety with explicit interfaces replacing `any`.
 - Logger interface cleaned up to remove duplicate fields.
 - Header visibility responds to scroll direction while reading.
+- Client-side state initialization avoids hydration mismatches.
 
 - Chapter images fetched via the MangaDex API with cached results (fallback to scraping).
 - Manga details cached for an hour to minimize API calls.

--- a/app/hooks/useFavorites.ts
+++ b/app/hooks/useFavorites.ts
@@ -4,13 +4,14 @@ import { Manga, FavoriteManga, ReadingStatus } from '../types/manga';
 const FAVORITES_KEY = 'mangaScraper_favorites';
 
 export function useFavorites() {
-  const [favorites, setFavorites] = useState<FavoriteManga[]>(() => {
+  const [favorites, setFavorites] = useState<FavoriteManga[]>([]);
+
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem(FAVORITES_KEY);
-      return saved ? JSON.parse(saved) : [];
+      setFavorites(saved ? JSON.parse(saved) : []);
     }
-    return [];
-  });
+  }, []);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,13 +18,14 @@ const MAX_HISTORY_ITEMS = 5;
 export default function Home() {
   const [results, setResults] = useState<Manga[]>([]);
   const [loading, setLoading] = useState(false);
-  const [searchHistory, setSearchHistory] = useState<string[]>(() => {
+  const [searchHistory, setSearchHistory] = useState<string[]>([]);
+
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('searchHistory');
-      return saved ? JSON.parse(saved) : [];
+      setSearchHistory(saved ? JSON.parse(saved) : []);
     }
-    return [];
-  });
+  }, []);
 
   const { favorites } = useFavorites();
 


### PR DESCRIPTION
## Summary
- avoid client/server state mismatch in Home page
- load favorites from local storage in an effect
- document hydration fix in README

## Testing
- `npm run lint --no-color`
- `npm audit --json`

------
https://chatgpt.com/codex/tasks/task_e_684319f0214c8326b6b5dd92b8cc93b9