### PR TITLE
feat(home): fetch real newest manga

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Manga details cached for an hour to minimize API calls.
 - Browser instance reused across chapter searches for faster scraping.
 - Common Puppeteer launch arguments moved to a `launchBrowser` utility.
+- New "Nouveautés" section shows latest manga using the MangaDex API.
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.

--- a/app/api/newest/route.ts
+++ b/app/api/newest/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import { Cache } from '@/app/utils/cache';
+import { retry } from '@/app/utils/retry';
+import { logger } from '@/app/utils/logger';
+import type {
+  MangaDexChaptersResponse,
+  MangaDexManga,
+  MangaDexRelationship,
+  MangaDexSearchResponse,
+  MangaDexChapter
+} from '@/app/types/mangadex';
+import type { Manga } from '@/app/types/manga';
+
+const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
+const cache = new Cache<Manga[]>(CACHE_DURATION);
+
+const fetchHttps = (url: string, options?: RequestInit) => {
+  if (!url.startsWith('https://')) {
+    throw new Error('Les requêtes externes doivent utiliser HTTPS');
+  }
+  return fetch(url, options);
+};
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Number(searchParams.get('limit') || '8');
+    const cacheKey = `newest_${limit}`;
+
+    const cached = await cache.get(cacheKey);
+    if (cached) {
+      return NextResponse.json({ success: true, results: cached, cached: true });
+    }
+
+    const params = new URLSearchParams();
+    params.append('limit', String(limit));
+    params.append('order[latestUploadedChapter]', 'desc');
+    params.append('includes[]', 'cover_art');
+    params.append('includes[]', 'author');
+    params.append('contentRating[]', 'safe');
+    params.append('contentRating[]', 'suggestive');
+
+    const url = `https://api.mangadex.org/manga?${params.toString()}`;
+
+    const response = await retry(
+      () => fetchHttps(url, { headers: { Accept: 'application/json' } }),
+      3,
+      1000
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.log('error', 'Erreur API MangaDex newest', {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText
+      });
+      throw new Error(`Erreur MangaDex: ${response.status}`);
+    }
+
+    const data: MangaDexSearchResponse = await response.json();
+
+    const results: Manga[] = await Promise.all(
+      data.data.map(async (manga: MangaDexManga) => {
+        try {
+          const cover = manga.relationships?.find(
+            (rel: MangaDexRelationship) => rel.type === 'cover_art'
+          );
+          const author = manga.relationships?.find(
+            (rel: MangaDexRelationship) => rel.type === 'author'
+          );
+          const totalChapters = manga.attributes?.lastChapter
+            ? parseInt(manga.attributes.lastChapter)
+            : 0;
+          const chaptersResponse = await retry(
+            () =>
+              fetchHttps(
+                `https://api.mangadex.org/manga/${manga.id}/feed?limit=0&translatedLanguage[]=fr&order[chapter]=desc`
+              ),
+            3,
+            1000
+          );
+          const chaptersData: MangaDexChaptersResponse = await chaptersResponse.json();
+          const frenchChapters = new Set(
+            chaptersData.data?.map((c: MangaDexChapter) => c.attributes.chapter)
+          ).size;
+
+          const coverFileName = cover?.attributes?.fileName;
+          const coverUrl = coverFileName
+            ? `https://uploads.mangadex.org/covers/${manga.id}/${coverFileName}`
+            : '';
+          const title =
+            manga.attributes.title.fr ||
+            manga.attributes.title.en ||
+            Object.values(manga.attributes.title)[0] ||
+            'Sans titre';
+          const availableLanguages =
+            manga.attributes.availableTranslatedLanguages || [];
+          const isAvailableInFrench = availableLanguages.includes('fr');
+          const originalLanguage = manga.attributes.originalLanguage;
+
+          return {
+            id: manga.id,
+            title,
+            description:
+              manga.attributes.description?.fr ||
+              manga.attributes.description?.en ||
+              '',
+            cover: coverUrl,
+            url: `https://mangadex.org/title/${manga.id}`,
+            type:
+              originalLanguage === 'ko'
+                ? 'manhwa'
+                : originalLanguage === 'zh'
+                  ? 'manhua'
+                  : 'manga',
+            status:
+              manga.attributes.status === 'ongoing' ? 'ongoing' : 'completed',
+            lastChapter:
+              totalChapters > 0
+                ? frenchChapters > 0
+                  ? `${frenchChapters}/${totalChapters}`
+                  : `${totalChapters}`
+                : '?',
+            chapterCount: { french: frenchChapters, total: totalChapters },
+            author: author?.attributes?.name || '',
+            year: manga.attributes.year || '',
+            rating: manga.attributes.contentRating || 'safe',
+            availableLanguages,
+            isAvailableInFrench,
+            originalLanguage
+          } as Manga;
+        } catch (error) {
+          logger.log('error', 'Erreur transformation newest', {
+            error: String(error),
+            mangaId: manga.id
+          });
+          return null;
+        }
+      })
+    ).then((res) => res.filter((m): m is Manga => m !== null));
+
+    await cache.set(cacheKey, results);
+
+    return NextResponse.json({ success: true, results, cached: false });
+  } catch (error) {
+    logger.log('error', 'Erreur récupération nouveautés', { error: String(error) });
+    return NextResponse.json(
+      { success: false, error: 'Erreur lors de la récupération des nouveautés' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/NewestSection.tsx
+++ b/app/components/NewestSection.tsx
@@ -1,68 +1,19 @@
 'use client';
 
 import { Clock, Sparkles, TrendingUp } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import LoadingSpinner from './LoadingSpinner';
 import ErrorMessage from './ErrorMessage';
-import DemoMangaCover from './DemoMangaCover';
+import { useNewest } from '../hooks/useNewest';
 
 interface NewestSectionProps {
   onSearch: (query: string) => void;
 }
 
-interface NewManga {
-  id: string;
-  title: string;
-  cover: string;
-  addedDate?: string;
-}
-
 const DEFAULT_COVER = '/images/default-cover.svg';
 
-// Mock data pour les nouveautés (à remplacer par de vraies données API)
-const MOCK_NEWEST: NewManga[] = [
-  { id: '1', title: 'Tower of God', cover: DEFAULT_COVER, addedDate: 'Il y a 2h' },
-  { id: '2', title: 'Solo Leveling', cover: DEFAULT_COVER, addedDate: 'Il y a 5h' },
-  { id: '3', title: 'The God of High School', cover: DEFAULT_COVER, addedDate: 'Il y a 1j' },
-  { id: '4', title: 'Noblesse', cover: DEFAULT_COVER, addedDate: 'Il y a 2j' },
-  { id: '5', title: 'Unordinary', cover: DEFAULT_COVER, addedDate: 'Il y a 3j' },
-  { id: '6', title: 'Lookism', cover: DEFAULT_COVER, addedDate: 'Il y a 4j' },
-  { id: '7', title: 'True Beauty', cover: DEFAULT_COVER, addedDate: 'Il y a 5j' },
-  { id: '8', title: 'Sweet Home', cover: DEFAULT_COVER, addedDate: 'Il y a 1s' }
-];
-
 export default function NewestSection({ onSearch }: NewestSectionProps) {
-  const [newest, setNewest] = useState<NewManga[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    // Simule un chargement asynchrone
-    const loadNewest = async () => {
-      try {
-        setLoading(true);
-        // Simule un délai de chargement
-        await new Promise(resolve => setTimeout(resolve, 800));
-        setNewest(MOCK_NEWEST);
-      } catch (err) {
-        setError('Impossible de charger les nouveautés');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadNewest();
-  }, []);
-
-  const refetch = () => {
-    setError(null);
-    setLoading(true);
-    // Simule un rechargement
-    setTimeout(() => {
-      setNewest(MOCK_NEWEST);
-      setLoading(false);
-    }, 500);
-  };
+  const { newest, loading, error, refetch } = useNewest(8);
 
   if (loading) {
     return (
@@ -128,11 +79,17 @@ export default function NewestSection({ onSearch }: NewestSectionProps) {
               className="group cursor-pointer" 
               onClick={() => onSearch(manga.title)}
             >
-              {/* Mini Cover */}              <div className="relative aspect-[3/4] rounded-md overflow-hidden bg-gray-800 border border-gray-700/50 hover:border-blue-500/50 transition-all duration-200 hover:shadow-lg hover:shadow-blue-500/10">
-                <DemoMangaCover
-                  title={manga.title}
-                  className="transition-transform group-hover:scale-105"
+              {/* Mini Cover */}
+              <div className="relative aspect-[3/4] rounded-md overflow-hidden bg-gray-800 border border-gray-700/50 hover:border-blue-500/50 transition-all duration-200 hover:shadow-lg hover:shadow-blue-500/10">
+                <Image
+                  src={manga.cover || DEFAULT_COVER}
+                  alt={manga.title}
+                  fill
+                  className="object-cover transition-transform group-hover:scale-105"
                   sizes="(max-width: 640px) 25vw, 12.5vw"
+                  onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                    (e.target as HTMLImageElement).src = DEFAULT_COVER;
+                  }}
                 />
                 
                 {/* New Badge */}
@@ -146,14 +103,6 @@ export default function NewestSection({ onSearch }: NewestSectionProps) {
                   </div>
                 </div>
                 
-                {/* Time indicator */}
-                {manga.addedDate && (
-                  <div className="absolute top-1 right-1">
-                    <div className="px-1 py-0.5 bg-black/60 backdrop-blur-sm rounded text-xs text-gray-300">
-                      {manga.addedDate}
-                    </div>
-                  </div>
-                )}
                 
                 {/* Hover Overlay */}
                 <div className="absolute inset-0 bg-gradient-to-t from-blue-500/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />

--- a/app/hooks/useNewest.ts
+++ b/app/hooks/useNewest.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Manga } from '../types/manga';
+import { getNewestManga } from '../services/scraping.service';
+
+export function useNewest(limit: number = 8) {
+  const [newest, setNewest] = useState<Manga[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNewest = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const cacheKey = `newest_manga_${limit}`;
+      const cached = localStorage.getItem(cacheKey);
+      const cacheExpiry = localStorage.getItem(`${cacheKey}_expiry`);
+      if (cached && cacheExpiry && Date.now() < parseInt(cacheExpiry)) {
+        setNewest(JSON.parse(cached));
+        setLoading(false);
+        return;
+      }
+      const data = await getNewestManga(limit);
+      setNewest(data);
+      localStorage.setItem(cacheKey, JSON.stringify(data));
+      localStorage.setItem(`${cacheKey}_expiry`, (Date.now() + 60 * 60 * 1000).toString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  }, [limit]);
+
+  const refetch = useCallback(() => {
+    const cacheKey = `newest_manga_${limit}`;
+    localStorage.removeItem(cacheKey);
+    localStorage.removeItem(`${cacheKey}_expiry`);
+    fetchNewest();
+  }, [fetchNewest, limit]);
+
+  useEffect(() => {
+    fetchNewest();
+  }, [fetchNewest]);
+
+  return { newest, loading, error, refetch };
+}

--- a/app/services/scraping.service.ts
+++ b/app/services/scraping.service.ts
@@ -101,3 +101,21 @@ export async function getBestSellerManga(limit: number = 8): Promise<Manga[]> {
     return [];
   }
 }
+export async function getNewestManga(limit: number = 8): Promise<Manga[]> {
+  try {
+    const response = await fetch(`/api/newest?limit=${limit}`);
+    if (!response.ok) {
+      throw new Error(`Erreur HTTP: ${response.status}`);
+    }
+    const data = await response.json();
+    if (!data.success) {
+      throw new Error(data.error || 'Erreur inconnue');
+    }
+    return data.results as Manga[];
+  } catch (error) {
+    logger.log('error', 'Erreur lors de la récupération des nouveautés', {
+      error: error instanceof Error ? error.message : 'Erreur inconnue'
+    });
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/newest` route using MangaDex API
- create `useNewest` hook with caching
- update `NewestSection` to load real covers
- document the new "Nouveautés" section in README

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_6843715c3a148326803b7d35b601417d