### PR TITLE
Add recommendation API and hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Browser instance reused across chapter searches for faster scraping.
 - Common Puppeteer launch arguments moved to a `launchBrowser` utility.
 - New "Nouveautés" section shows latest manga using the MangaDex API.
+- Personalized recommendations via `/api/recommendations` with local caching.
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.
@@ -72,6 +73,10 @@ When you open a chapter, a progress bar at the top indicates how many pages have
 finished loading compared to the total number of pages. This helps you monitor
 the loading status as you read
 and relies on the `pageCount`/`pages` values returned by the API.
+
+Use the `useRecommendations` hook to display manga suggestions based on the
+reading history stored in a cookie. Results are cached in `localStorage` for one
+hour.
 
 ## Project Setup
 

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -1,0 +1,53 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { Cache } from '@/app/utils/cache';
+import { logger } from '@/app/utils/logger';
+import { getTrendingManga, getBestSellerManga } from '@/app/services/scraping.service';
+import type { Manga } from '@/app/types/manga';
+
+const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
+const cache = new Cache<Manga[]>(CACHE_DURATION);
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Number(searchParams.get('limit') || '6');
+    const cookieStore = cookies();
+    const historyCookie = cookieStore.get('reading_history');
+    let history: string[] = [];
+    if (historyCookie) {
+      try {
+        const parsed = JSON.parse(historyCookie.value);
+        if (Array.isArray(parsed)) {
+          history = parsed.slice(0, 20).map((id) => String(id));
+        }
+      } catch (err) {
+        logger.log('warning', 'Invalid reading_history cookie', { error: String(err) });
+      }
+    }
+
+    const cacheKey = `recommendations_${history.sort().join('_')}_${limit}`;
+    const cached = await cache.get(cacheKey);
+    if (cached) {
+      return NextResponse.json({ success: true, results: cached, cached: true });
+    }
+
+    let candidates: Manga[] = [];
+    try {
+      const trending = await getTrendingManga(limit * 2);
+      const bestSellers = await getBestSellerManga(limit * 2);
+      candidates = [...trending, ...bestSellers];
+    } catch (err) {
+      logger.log('error', 'Failed to fetch candidate mangas', { error: String(err) });
+    }
+
+    const filtered = candidates.filter((m) => !history.includes(m.id));
+    const recommendations = filtered.slice(0, limit);
+    await cache.set(cacheKey, recommendations);
+
+    return NextResponse.json({ success: true, results: recommendations, cached: false });
+  } catch (error) {
+    logger.log('error', 'Erreur génération recommandations', { error: String(error) });
+    return NextResponse.json({ success: false, error: 'Erreur lors des recommandations' }, { status: 500 });
+  }
+}

--- a/app/components/RecommendationsSection.tsx
+++ b/app/components/RecommendationsSection.tsx
@@ -1,74 +1,21 @@
 'use client';
 
-import { Heart, Zap, Target, User } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { Heart, Target, User } from 'lucide-react';
+import Image from 'next/image';
 import { useFavorites } from '../hooks/useFavorites';
+import { useRecommendations } from '../hooks/useRecommendations';
 import LoadingSpinner from './LoadingSpinner';
 import ErrorMessage from './ErrorMessage';
-import DemoMangaCover from './DemoMangaCover';
 
 interface RecommendationsSectionProps {
   onSearch: (query: string) => void;
 }
 
-interface RecommendedManga {
-  id: string;
-  title: string;
-  cover: string;
-  reason: string;
-  matchScore: number;
-}
-
 const DEFAULT_COVER = '/images/default-cover.svg';
 
-// Mock des recommandations (à remplacer par une vraie logique de recommandation)
-const MOCK_RECOMMENDATIONS: RecommendedManga[] = [
-  { id: '1', title: 'Attack on Titan', cover: DEFAULT_COVER, reason: 'Action, Drama', matchScore: 95 },
-  { id: '2', title: 'Demon Slayer', cover: DEFAULT_COVER, reason: 'Supernatural', matchScore: 92 },
-  { id: '3', title: 'My Hero Academia', cover: DEFAULT_COVER, reason: 'School Life, Action', matchScore: 88 },
-  { id: '4', title: 'One Piece', cover: DEFAULT_COVER, reason: 'Adventure', matchScore: 85 },
-  { id: '5', title: 'Jujutsu Kaisen', cover: DEFAULT_COVER, reason: 'Supernatural, Action', matchScore: 90 },
-  { id: '6', title: 'Chainsaw Man', cover: DEFAULT_COVER, reason: 'Horror, Action', matchScore: 87 }
-];
-
 export default function RecommendationsSection({ onSearch }: RecommendationsSectionProps) {
-  const [recommendations, setRecommendations] = useState<RecommendedManga[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { recommendations, loading, error, refetch } = useRecommendations(6);
   const { favorites } = useFavorites();
-
-  useEffect(() => {
-    const loadRecommendations = async () => {
-      try {
-        setLoading(true);
-        // Simule une analyse des favoris pour générer des recommandations
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        
-        // Si l'utilisateur a des favoris, on adapte les recommandations
-        if (favorites.length > 0) {
-          setRecommendations(MOCK_RECOMMENDATIONS.slice(0, 6));
-        } else {
-          // Recommandations génériques pour nouveaux utilisateurs
-          setRecommendations(MOCK_RECOMMENDATIONS.slice(0, 4));
-        }
-      } catch (err) {
-        setError('Impossible de charger les recommandations');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadRecommendations();
-  }, [favorites]);
-
-  const refetch = () => {
-    setError(null);
-    setLoading(true);
-    setTimeout(() => {
-      setRecommendations(MOCK_RECOMMENDATIONS);
-      setLoading(false);
-    }, 500);
-  };
 
   if (loading) {
     return (
@@ -139,57 +86,44 @@ export default function RecommendationsSection({ onSearch }: RecommendationsSect
       </div>
       
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
-        {recommendations.map((manga, index) => {
-          const matchLevel = manga.matchScore >= 90 ? 'excellent' : manga.matchScore >= 85 ? 'good' : 'decent';
-          const matchColor = {
-            excellent: 'from-green-500 to-emerald-500',
-            good: 'from-blue-500 to-cyan-500', 
-            decent: 'from-gray-500 to-gray-600'
-          };
-          
-          return (
-            <div 
-              key={manga.id} 
-              className="group cursor-pointer" 
-              onClick={() => onSearch(manga.title)}
-            >
-              {/* Cover */}              <div className="relative aspect-[3/4] rounded-lg overflow-hidden bg-gray-800 border border-gray-700/50 hover:border-purple-500/50 transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/10">
-                <DemoMangaCover
-                  title={manga.title}
-                  className="transition-transform group-hover:scale-105"
-                  sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 16.66vw"
-                />
-                
-                {/* Match Score Badge */}
-                <div className="absolute top-2 left-2">
-                  <div className={`px-2 py-1 bg-gradient-to-r ${matchColor[matchLevel]} rounded-full text-xs font-bold text-white shadow-lg`}>
-                    {manga.matchScore}%
-                  </div>
+        {recommendations.map((manga) => (
+          <div
+            key={manga.id}
+            className="group cursor-pointer"
+            onClick={() => onSearch(manga.title)}
+          >
+            {/* Cover */}
+            <div className="relative aspect-[3/4] rounded-lg overflow-hidden bg-gray-800 border border-gray-700/50 hover:border-purple-500/50 transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/10">
+              <Image
+                src={manga.cover || DEFAULT_COVER}
+                alt={manga.title}
+                fill
+                className="object-cover transition-transform group-hover:scale-105"
+                sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 16.66vw"
+                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                  (e.target as HTMLImageElement).src = DEFAULT_COVER;
+                }}
+              />
+
+              {/* Hover Overlay */}
+              <div className="absolute inset-0 bg-gradient-to-t from-purple-500/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+
+              {/* Heart Icon on hover */}
+              <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                <div className="w-6 h-6 bg-purple-500/90 backdrop-blur-sm rounded-full flex items-center justify-center shadow-lg">
+                  <Heart className="w-3 h-3 text-white" />
                 </div>
-                
-                {/* Hover Overlay */}
-                <div className="absolute inset-0 bg-gradient-to-t from-purple-500/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                
-                {/* Heart Icon on hover */}
-                <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                  <div className="w-6 h-6 bg-purple-500/90 backdrop-blur-sm rounded-full flex items-center justify-center shadow-lg">
-                    <Heart className="w-3 h-3 text-white" />
-                  </div>
-                </div>
-              </div>
-              
-              {/* Info */}
-              <div className="mt-2 space-y-1">
-                <h4 className="text-xs font-medium text-white group-hover:text-purple-300 transition-colors line-clamp-2 leading-tight">
-                  {manga.title}
-                </h4>
-                <p className="text-xs text-gray-500 group-hover:text-gray-400 transition-colors">
-                  {manga.reason}
-                </p>
               </div>
             </div>
-          );
-        })}
+
+            {/* Info */}
+            <div className="mt-2 space-y-1">
+              <h4 className="text-xs font-medium text-white group-hover:text-purple-300 transition-colors line-clamp-2 leading-tight">
+                {manga.title}
+              </h4>
+            </div>
+          </div>
+        ))}
       </div>
       
       {/* Footer message */}

--- a/app/hooks/useRecommendations.ts
+++ b/app/hooks/useRecommendations.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Manga } from '../types/manga';
+
+const CACHE_KEY = 'user_recommendations';
+const CACHE_EXPIRY = `${CACHE_KEY}_expiry`;
+
+export function useRecommendations(limit: number = 6) {
+  const [recommendations, setRecommendations] = useState<Manga[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRecommendations = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const cached = localStorage.getItem(CACHE_KEY);
+      const expiry = localStorage.getItem(CACHE_EXPIRY);
+      if (cached && expiry && Date.now() < parseInt(expiry)) {
+        setRecommendations(JSON.parse(cached));
+        setLoading(false);
+        return;
+      }
+      const resp = await fetch(`/api/recommendations?limit=${limit}`, { credentials: 'include' });
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const data = await resp.json();
+      if (!data.success) {
+        throw new Error(data.error || 'Erreur inconnue');
+      }
+      setRecommendations(data.results as Manga[]);
+      localStorage.setItem(CACHE_KEY, JSON.stringify(data.results));
+      localStorage.setItem(CACHE_EXPIRY, (Date.now() + 60 * 60 * 1000).toString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  }, [limit]);
+
+  const refetch = useCallback(() => {
+    localStorage.removeItem(CACHE_KEY);
+    localStorage.removeItem(CACHE_EXPIRY);
+    fetchRecommendations();
+  }, [fetchRecommendations]);
+
+  useEffect(() => {
+    fetchRecommendations();
+  }, [fetchRecommendations]);
+
+  return { recommendations, loading, error, refetch };
+}


### PR DESCRIPTION
## Summary
- add new `/api/recommendations` route with caching and cookie-based history
- implement `useRecommendations` hook to cache results in localStorage
- update `RecommendationsSection` to use the hook
- document the new feature in the README

## Testing
- `npx eslint app/api/recommendations/route.ts app/hooks/useRecommendations.ts app/components/RecommendationsSection.tsx`
- `npm audit`
- `npx vitest run` *(fails: useChapterNavigation tests)*
- `npx -y lighthouse http://localhost:3000 --quiet --chrome-flags=--headless` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_68442ae064948326b642dd5c1dc4113b