### PR TITLE
Fix README link to AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
-For an overview of the technical foundations and planned improvements, see [agent.md](./agent.md).
+For an overview of the technical foundations and planned improvements, see [AGENTS.md](./AGENTS.md).
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- fix broken reference to the project AGENTS file in README

## Testing
- `npm run lint`
- `npx vitest run`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68442ae2f7a48326af704c9164da5c5b