### PR TITLE
Track reading history in cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Common Puppeteer launch arguments moved to a `launchBrowser` utility.
 - New "Nouveautés" section shows latest manga using the MangaDex API.
 - Personalized recommendations via `/api/recommendations` with local caching.
+- Recently read manga IDs stored in the `reading_history` cookie (last 20).
 
 - Rate limiter on `/api/scraper` prevents abusive calls.
 - Search queries are sanitized and only HTTPS requests are allowed.
@@ -75,9 +76,9 @@ finished loading compared to the total number of pages. This helps you monitor
 the loading status as you read
 and relies on the `pageCount`/`pages` values returned by the API.
 
-Use the `useRecommendations` hook to display manga suggestions based on the
-reading history stored in a cookie. Results are cached in `localStorage` for one
-hour.
+Use the `useRecommendations` hook to display manga suggestions. The
+`reading_history` cookie tracks your last 20 mangas and is sent to the API for
+personalized results. Recommendations are cached in `localStorage` for one hour.
 
 ## Project Setup
 

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -19,10 +19,14 @@ export async function GET(request: Request) {
       try {
         const parsed = JSON.parse(historyCookie.value);
         if (Array.isArray(parsed)) {
-          history = parsed.slice(0, 20).map((id) => String(id));
+          history = Array.from(new Set(parsed))
+            .slice(0, 20)
+            .map((id) => String(id));
         }
       } catch (err) {
-        logger.log('warning', 'Invalid reading_history cookie', { error: String(err) });
+        logger.log('warning', 'Invalid reading_history cookie', {
+          error: String(err),
+        });
       }
     }
 

--- a/app/manga/[id]/chapter/[chapterId]/page.tsx
+++ b/app/manga/[id]/chapter/[chapterId]/page.tsx
@@ -41,6 +41,30 @@ function ChapterReaderContent() {
   );
   const { updateReadingProgress } = useReadingProgress();
 
+  const updateHistoryCookie = (id: string) => {
+    if (typeof document === 'undefined') return;
+    try {
+      const cookie = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('reading_history='));
+      let history: string[] = [];
+      if (cookie) {
+        const value = decodeURIComponent(cookie.split('=')[1]);
+        const parsed = JSON.parse(value);
+        if (Array.isArray(parsed)) {
+          history = parsed;
+        }
+      }
+      const filtered = history.filter((h) => h !== id);
+      const updated = [id, ...filtered].slice(0, 20);
+      document.cookie = `reading_history=${encodeURIComponent(
+        JSON.stringify(updated)
+      )};path=/;max-age=${60 * 60 * 24 * 30}`;
+    } catch {
+      // ignore cookie errors
+    }
+  };
+
   useEffect(() => {
     const fetchChapterData = async () => {
       try {
@@ -115,6 +139,7 @@ function ChapterReaderContent() {
             coverUrl,
             data.language
           );
+          updateHistoryCookie(mangaId);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Une erreur est survenue';


### PR DESCRIPTION
## Summary
- push manga IDs into `reading_history` cookie when updating reading progress
- deduplicate and cap history in recommendations API
- document new behaviour in README

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_68443159b45483268a7a0a873f16095a