### PR TITLE
feat(context): partage global des favoris

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Logger interface cleaned up to remove duplicate fields.
 - Header visibility responds to scroll direction while reading.
 - Client-side state initialization avoids hydration mismatches.
+- Global `FavoritesProvider` context shares the favorites list across pages.
+- LocalStorage updates occur synchronously when modifying favorites.
 - Configuration unified under `next.config.ts` with custom image patterns and API rewrites.
 
 - Chapter images fetched via the MangaDex API with cached results (fallback to scraping).

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import HydrationFix from "./components/HydrationFix";
+import { FavoritesProvider } from "./hooks/useFavorites";
 
 // Import diagnostics pour le mode développement
 if (process.env.NODE_ENV === 'development') {
@@ -29,12 +30,15 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="fr" suppressHydrationWarning>      <body
+    <html lang="fr" suppressHydrationWarning>
+      <body
         suppressHydrationWarning={true}
         className={`${geistSans.variable} ${geistMono.variable} font-sans`}
       >
         <HydrationFix />
-        {children}
+        <FavoritesProvider>
+          {children}
+        </FavoritesProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- save favorites in localStorage before navigation
- share favorite mangas across pages with `FavoritesProvider`
- wrap layout with the new provider
- document the global context in README

## Testing
- `npm run lint`
- `npx vitest run` *(fails: useChapterNavigation tests)*
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68443149359c8326a6af978f9b23563c