### PR TITLE
Fix favorites not loading on /favorites page

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Personalized recommendations via `/api/recommendations` with local caching.
 
 - Unit tests verify favorites persistence and recommendation caching.
+- Favorites loaded from `localStorage` on initial render prevent empty favorites
+  pages and ensure your list persists across sessions.
 - Recently read manga IDs stored in the `reading_history` cookie (last 20).
 
 - Rate limiter on `/api/scraper` prevents abusive calls.

--- a/app/hooks/useFavorites.ts
+++ b/app/hooks/useFavorites.ts
@@ -1,19 +1,26 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Manga, FavoriteManga, ReadingStatus } from '../types/manga';
 
 const FAVORITES_KEY = 'mangaScraper_favorites';
 
 export function useFavorites() {
-  const [favorites, setFavorites] = useState<FavoriteManga[]>([]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
+  const [favorites, setFavorites] = useState<FavoriteManga[]>(() => {
+    if (typeof window === 'undefined') return [];
+    try {
       const saved = localStorage.getItem(FAVORITES_KEY);
-      setFavorites(saved ? JSON.parse(saved) : []);
+      return saved ? JSON.parse(saved) : [];
+    } catch {
+      return [];
     }
-  }, []);
+  });
+
+  const isInitialMount = useRef(true);
 
   useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
     if (typeof window !== 'undefined') {
       localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
     }


### PR DESCRIPTION
## Summary
- fix favorites hook so data loads from localStorage before initial render
- document the persistent favorites feature in the README

## Testing
- `npm run lint` *(fails: unexpected any, unused vars, etc.)*
- `npx vitest run`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_6844712eb6ec83268f79eaa7daf001f5