### PR TITLE
Fix trailing newline in ReadingStatus type

### DIFF
--- a/app/types/manga.ts
+++ b/app/types/manga.ts
@@ -27,4 +27,4 @@ export interface FavoriteManga extends Manga {
   readingStatus?: 'to-read' | 'reading' | 'completed';
 }
 
-export type ReadingStatus = 'to-read' | 'reading' | 'completed'; 
+export type ReadingStatus = 'to-read' | 'reading' | 'completed';


### PR DESCRIPTION
## Summary
- ensure `ReadingStatus` type declaration ends with a newline
- run `npm run lint` to check for TypeScript errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68447732abec8326a15c7b6a939ddba1