### PR TITLE
fix(favorites): add explicit types for state variables

### DIFF
--- a/app/components/FavoritesList-new.tsx
+++ b/app/components/FavoritesList-new.tsx
@@ -23,14 +23,14 @@ export default function FavoritesList({
 }: FavoritesListProps) {
   const router = useRouter();
   const { readingProgress } = useReadingProgress();
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState<string>('');
   const [sortBy, setSortBy] = useState<'recent' | 'title' | 'status' | 'progress'>('recent');
   const [activeMenu, setActiveMenu] = useState<string | null>(null);
   const [editingNote, setEditingNote] = useState<string | null>(null);
-  const [noteText, setNoteText] = useState('');
+  const [noteText, setNoteText] = useState<string>('');
 
   // Filtrage et tri simplifiés
-  const filteredAndSortedFavorites = favorites
+  const filteredAndSortedFavorites: FavoriteManga[] = favorites
     .filter((manga) => {
       if (!searchQuery) return true;
       const query = searchQuery.toLowerCase();
@@ -278,7 +278,7 @@ export default function FavoritesList({
                 {manga.notes && editingNote !== manga.id && (
                   <div className="bg-gray-800/30 rounded-lg p-2 mb-2">
                     <p className="text-xs text-gray-400 line-clamp-2 italic">
-                      "{manga.notes}"
+                      &quot;{manga.notes}&quot;
                     </p>
                   </div>
                 )}
@@ -332,7 +332,7 @@ export default function FavoritesList({
       {/* Message si aucun résultat */}
       {filteredAndSortedFavorites.length === 0 && searchQuery && (
         <div className="text-center py-12">
-          <p className="text-gray-400">Aucun manga trouvé pour "{searchQuery}"</p>
+          <p className="text-gray-400">Aucun manga trouvé pour &quot;{searchQuery}&quot;</p>
         </div>
       )}
 

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -17,9 +17,9 @@ export default function SearchBar({
   searchHistory = [], 
   onClearHistory 
 }: SearchBarProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showHistory, setShowHistory] = useState(false);
-  const [isFocused, setIsFocused] = useState(false);
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [showHistory, setShowHistory] = useState<boolean>(false);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
   const searchBarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -7,16 +7,17 @@ import { Heart, Search, Grid3X3, List, ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import FavoriteCard from '@/app/components/FavoriteCard';
 import FavoriteListItem from '@/app/components/FavoriteListItem';
+import type { FavoriteManga } from '@/app/types/manga';
 
 export default function FavoritesPage() {
   const { favorites, removeFromFavorites, updateReadingStatus, addNote } = useFavorites();
   const { readingProgress } = useReadingProgress();
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState<string>('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [sortBy, setSortBy] = useState<'recent' | 'title' | 'status' | 'progress'>('recent');
 
   // Filtrage et tri
-  const filteredAndSortedFavorites = favorites
+  const filteredAndSortedFavorites: FavoriteManga[] = favorites
     .filter((manga) => {
       if (!searchQuery) return true;
       const query = searchQuery.toLowerCase();
@@ -32,22 +33,35 @@ export default function FavoritesPage() {
         case 'title':
           return a.title.localeCompare(b.title);
         case 'status':
-          const statusOrder = { 'reading': 0, 'to-read': 1, 'completed': 2 } as const;
-          const statusA = a.readingStatus || 'to-read';
-          const statusB = b.readingStatus || 'to-read';
+          const statusOrder: Record<
+            'reading' | 'to-read' | 'completed',
+            number
+          > = { 'reading': 0, 'to-read': 1, 'completed': 2 };
+          const statusA: 'reading' | 'to-read' | 'completed' =
+            a.readingStatus || 'to-read';
+          const statusB: 'reading' | 'to-read' | 'completed' =
+            b.readingStatus || 'to-read';
           return statusOrder[statusA] - statusOrder[statusB];
         case 'progress':
-          const progressA = readingProgress.find(p => p.mangaId === a.id);
-          const progressB = readingProgress.find(p => p.mangaId === b.id);
-          const lastReadA = progressA?.lastReadAt ? new Date(progressA.lastReadAt).getTime() : 0;
-          const lastReadB = progressB?.lastReadAt ? new Date(progressB.lastReadAt).getTime() : 0;
+          const progressA = readingProgress.find(
+            (p) => p.mangaId === a.id
+          );
+          const progressB = readingProgress.find(
+            (p) => p.mangaId === b.id
+          );
+          const lastReadA: number = progressA?.lastReadAt
+            ? new Date(progressA.lastReadAt).getTime()
+            : 0;
+          const lastReadB: number = progressB?.lastReadAt
+            ? new Date(progressB.lastReadAt).getTime()
+            : 0;
           return lastReadB - lastReadA;
         default:
           return 0;
       }
     });
 
-  const EmptyState = () => (
+  const EmptyState = (): JSX.Element => (
     <div className="flex flex-col items-center justify-center min-h-[60vh]">
       <div className="w-20 h-20 rounded-full bg-gray-800/50 flex items-center justify-center mb-6">
         <Heart className="w-10 h-10 text-gray-600" />
@@ -65,7 +79,7 @@ export default function FavoritesPage() {
     </div>
   );
 
-  const NoResults = () => (
+  const NoResults = (): JSX.Element => (
     <div className="text-center py-16">
       <p className="text-gray-400 text-lg">Aucun résultat pour &quot;{searchQuery}&quot;</p>
     </div>


### PR DESCRIPTION
## Summary
- add missing type annotations for favorites page state
- type search bar states explicitly
- ensure favorites list uses typed state and strings

## Testing
- `npx next lint --file app/favorites/page.tsx app/components/SearchBar.tsx app/components/FavoritesList-new.tsx`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684727f1511c8326a30b09bf28777cac