### PR TITLE
feat(chapters): retrieve from fastest source

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - The `Strict-Transport-Security` header enforces HTTPS for two years across all subdomains.
 - MangaDex API requests automatically retry up to three times on network errors.
 - In-memory cache automatically prunes expired entries to limit memory usage.
-
-- Multi-source search aggregates MangaDex, Kitsu and Komga before falling back to scraping.
+ - Multi-source search aggregates MangaDex, Kitsu and Komga before falling back to scraping.
+ - Chapters are fetched concurrently from MangaDex, Webtoons and Komga, returning the fastest result.
 - Connection pooling via `undici` enables HTTP/2 requests with configurable concurrency.
 - Request queue ensures a controlled number of concurrent scraping jobs with configurable backoff.
 


### PR DESCRIPTION
## Summary
- add Komga as an optional chapter source
- fetch chapters from all sources concurrently and return the first successful result
- document faster chapter retrieval in README

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684747a0216c83268d44aaa56626855c