### PR TITLE
Refactor sources into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
  - Multi-source search aggregates MangaDex, Kitsu and Komga before falling back to scraping.
  - Chapters are fetched concurrently from MangaDex, Webtoons and Komga, returning the fastest result.
 - Connection pooling via `undici` enables HTTP/2 requests with configurable concurrency.
+- Source handlers are modularized under `app/services/sources` for easier maintenance.
 - Request queue ensures a controlled number of concurrent scraping jobs with configurable backoff.
 
 

--- a/app/api/manga/[id]/chapters/route.ts
+++ b/app/api/manga/[id]/chapters/route.ts
@@ -1,822 +1,31 @@
 import { NextResponse } from 'next/server';
-import { launchBrowser } from '@/app/utils/launchBrowser';
-import type { Page, Browser } from 'puppeteer';
 import { Cache } from '@/app/utils/cache';
 import { logger } from '@/app/utils/logger';
 import { retry } from '@/app/utils/retry';
-import type {
-  MangaDexChapter,
-  MangaDexChaptersResponse
-} from '@/app/types/mangadex';
-import { toomicsSource } from '@/app/services/sources';
+import type { ChapterData, ChaptersResult, Source, SourceSearchResult, SourceInfo } from '@/app/types/source';
+import { mangadexSource, webtoonsSource, komgaSource, toomicsSource } from '@/app/services/sources';
 
-// Types pour le cache des chapitres
 interface ChaptersCacheData extends ChaptersResult {
   source: SourceInfo;
 }
 
-// Types pour les résultats de recherche
-// Cache pour les chapitres (2 heures)
 const chaptersCache = new Cache<ChaptersCacheData>(7200000);
 
-
-interface ChapterData {
-  id: string;
-  chapter: string;
-  title: string | null;
-  publishedAt: string | null;
-  url: string;
-  source: string;
-  language?: string; // Code langue ISO (fr, en, ja, etc.)
-}
-
-
-interface ChaptersResult {
-  chapters: ChapterData[];
-  totalChapters: number;
-  source: {
-    name: string;
-    url: string;
-    titleId: string;
-  };
-}
-
-interface SourceSearchResult {
-  source: string;
-  titleId: string;
-  url: string;
-  sourceObj: Source;
-}
-
-interface SourceInfo {
-  name: string;
-  url: string;
-  titleId: string;
-}
-
-// Interface pour les sources
-interface Source {
-  name: string;
-  baseUrl: string;
-  search: (title: string) => Promise<{ titleId: string | null; url: string | null }>;
-  getChapters: (titleId: string, url: string) => Promise<ChaptersResult>;
-}
-
-// Navigateur réutilisé entre les appels
-let browserPromise: Promise<Browser> | null = null;
-
-async function getBrowser(): Promise<Browser> {
-  if (!browserPromise) {
-    browserPromise = launchBrowser({
-      headless: false,
-      args: [
-        '--disable-accelerated-2d-canvas',
-        '--disable-gpu',
-        '--window-size=1920x1080',
-        '--disable-features=IsolateOrigins,site-per-process',
-        '--disable-blink-features=AutomationControlled'
-      ],
-      defaultViewport: null
-    });
-  }
-  return browserPromise;
-}
-
-const closeBrowser = async () => {
-  if (browserPromise) {
-    const browser = await browserPromise;
-    await browser.close();
-    browserPromise = null;
-  }
-};
-
-process.on('exit', () => {
-  void closeBrowser();
-});
-process.on('SIGINT', () => {
-  void closeBrowser().then(() => process.exit(0));
-});
-
-// Configuration du navigateur de base
-async function setupBrowser() {
-  const browser = await getBrowser();
-
-  const page = await browser.newPage();
-  
-  // Configuration anti-détection
-  await page.evaluateOnNewDocument(() => {
-    delete Object.getPrototypeOf(navigator).webdriver;
-    // @ts-expect-error -- navigator.chrome is not a standard property
-    window.navigator.chrome = {
-      runtime: {},
-    };
-    Object.defineProperty(navigator, 'languages', {
-      get: () => ['fr-FR', 'fr', 'en-US', 'en'],
-    });
-    Object.defineProperty(navigator, 'plugins', {
-      get: () => [
-        {
-          0: {type: "application/x-google-chrome-pdf"},
-          description: "Portable Document Format",
-          filename: "internal-pdf-viewer",
-          length: 1,
-          name: "Chrome PDF Plugin"
-        }
-      ],
-    });
-  });
-
-  // Configuration des en-têtes
-  await page.setExtraHTTPHeaders({
-    'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
-    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-    'Accept-Encoding': 'gzip, deflate, br',
-    'Connection': 'keep-alive',
-    'Cache-Control': 'max-age=0',
-    'sec-ch-ua': '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
-    'sec-ch-ua-mobile': '?0',
-    'sec-ch-ua-platform': '"Windows"',
-    'Upgrade-Insecure-Requests': '1',
-    'Sec-Fetch-Site': 'none',
-    'Sec-Fetch-Mode': 'navigate',
-    'Sec-Fetch-User': '?1',
-    'Sec-Fetch-Dest': 'document'
-  });
-
-  await page.setViewport({ width: 1920, height: 1080 });
-
-  return { browser, page };
-}
-
-
-
-// Fonction pour contourner Cloudflare
-async function handleCloudflare(page: Page): Promise<boolean> {
-  try {
-    logger.log('info', 'Tentative de contournement de Cloudflare');
-    
-    // Attendre que le challenge Cloudflare soit visible
-    await page.waitForFunction(() => {
-      return document.querySelector('#challenge-form') !== null ||
-             document.querySelector('#cf-challenge-running') !== null ||
-             document.querySelector('#cf-spinner') !== null;
-    }, { timeout: 5000 }).catch(() => null);
-
-    // Attendre un peu pour laisser Cloudflare initialiser son challenge
-    await sleep(2000);
-
-    // Simuler des mouvements de souris aléatoires
-    for (let i = 0; i < 5; i++) {
-      const x = Math.floor(Math.random() * 1000);
-      const y = Math.floor(Math.random() * 1000);
-      await page.mouse.move(x, y);
-      await sleep(500);
-    }
-
-    // Attendre que le challenge soit complété
-    await Promise.race([
-      page.waitForFunction(() => {
-        return document.querySelector('#challenge-form') === null &&
-               document.querySelector('#cf-challenge-running') === null &&
-               document.querySelector('#cf-spinner') === null;
-      }, { timeout: 30000 }),
-      page.waitForNavigation({ timeout: 30000, waitUntil: 'networkidle0' })
-    ]);
-
-    // Vérifier si nous avons passé Cloudflare
-    const content = await page.content();
-    if (content.includes('cf-browser-verification') || 
-        content.includes('cf-challenge-running') ||
-        content.includes('_cf_chl_opt')) {
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    logger.log('error', 'Erreur lors du contournement de Cloudflare', {
-      error: error instanceof Error ? error.message : 'Erreur inconnue'
-    });
-    return false;
-  }
-}
-
-// Fonction pour contourner les blocages avec gestion de Cloudflare
-async function bypassBlocker(page: Page, url: string, maxRetries = 3): Promise<boolean> {
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      logger.log('info', 'Tentative de contournement du blocage', {
-        attempt: i + 1,
-        maxRetries,
-        url
-      });
-
-      // Délai aléatoire entre les tentatives
-      const delay = Math.floor(Math.random() * 5000) + 5000;
-      await sleep(delay);
-
-      // Navigation vers la page
-      await page.goto(url, { 
-        waitUntil: 'networkidle0',
-        timeout: 60000
-      });
-
-      // Vérifier si nous sommes face à Cloudflare
-      const isCloudflare = await page.evaluate(() => {
-        return document.body.textContent?.toLowerCase().includes('cloudflare') ||
-               document.querySelector('#challenge-form, #cf-challenge-running, #cf-spinner') !== null;
-      });
-
-      if (isCloudflare) {
-        logger.log('info', 'Détection de Cloudflare, tentative de contournement');
-        const cloudflareBypass = await handleCloudflare(page);
-        if (!cloudflareBypass) {
-          logger.log('warning', 'Échec du contournement de Cloudflare');
-          continue;
-        }
-      }
-
-      // Vérifier le contenu de la page
-      const pageStatus = await page.evaluate(() => {
-        const selectors = {
-          validContent: '.manga-title, .chapter-list, .manga-info, .search-results, .chapters-list',
-          errorIndicators: {
-            error404: '.error-404, .not-found',
-            blocked: '.blocked-message, .block-message',
-            captcha: '#captcha, .captcha, .g-recaptcha',
-            cloudflare: '#challenge-form, #cf-challenge-running'
-          }
-        };
-
-        const hasValidContent = !!document.querySelector(selectors.validContent);
-        const errors = Object.entries(selectors.errorIndicators).reduce((acc, [key, selector]) => {
-          acc[key] = !!document.querySelector(selector);
-          return acc;
-        }, {} as Record<string, boolean>);
-
-        return { hasValidContent, errors };
-      });
-
-      if (pageStatus.hasValidContent) {
-        logger.log('info', 'Contournement réussi', {
-          attempt: i + 1,
-          url
-        });
-        return true;
-      }
-
-      logger.log('warning', 'Page invalide, nouvelle tentative', {
-        attempt: i + 1,
-        url,
-        pageStatus
-      });
-
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la tentative de contournement', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue',
-        attempt: i + 1,
-        url
-      });
-    }
-  }
-
-  return false;
-}
-
-
-// Source Webtoon
-const webtoonSource: Source = {
-  name: 'webtoons',
-  baseUrl: 'https://www.webtoons.com',
-  search: async (title: string) => {
-    try {
-      const browser = await getBrowser();
-      const page = await browser.newPage();
-      await page.setViewport({ width: 1920, height: 1080 });
-      await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');
-
-      const searchUrl = `${webtoonSource.baseUrl}/fr/search?keyword=${encodeURIComponent(title)}`;
-      logger.log('info', 'Recherche sur Webtoons', { query: title });
-      
-      await page.goto(searchUrl, { waitUntil: 'networkidle0' });
-      await sleep(5000);
-
-      await page.waitForFunction(() => {
-        return document.querySelector('.card_item') !== null || 
-               document.querySelector('.search_result') !== null;
-      }, { timeout: 10000 });
-
-      const result = await page.evaluate((query: string) => {
-        const cards = document.querySelectorAll('.card_item');
-        let bestMatch = null;
-        let bestScore = 0;
-
-        for (const card of Array.from(cards)) {
-          const titleEl = card.querySelector('.subj');
-          const link = card.querySelector('a');
-          if (titleEl && link) {
-            const title = titleEl.textContent?.toLowerCase() || '';
-            const href = link.getAttribute('href') || '';
-            const match = href.match(/title_no=(\d+)/);
-
-            if (match) {
-              const words1 = query.toLowerCase().split(' ');
-              const words2 = title.split(' ');
-              const commonWords = words1.filter(w => words2.includes(w));
-              const score = commonWords.length / Math.max(words1.length, words2.length);
-
-              if (score > bestScore) {
-                bestScore = score;
-                bestMatch = { titleId: match[1], url: href, score };
-              }
-            }
-          }
-        }
-
-        return bestMatch;
-      }, title);
-
-      await page.close();
-
-      if (result && result.score > 0.3) {
-        logger.log('info', 'Manga trouvé sur Webtoons', { query: title });
-        return { titleId: result.titleId, url: result.url };
-      }
-
-      logger.log('info', 'Manga non trouvé sur Webtoons', { query: title });
-      return { titleId: null, url: null };
-
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la recherche sur Webtoons', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue'
-      });
-      return { titleId: null, url: null };
-    }
-  },
-  getChapters: async (titleId: string, url: string): Promise<ChaptersResult> => {
-    try {
-      const browser = await getBrowser();
-      const page = await browser.newPage();
-      await page.setViewport({ width: 1920, height: 1080 });
-      await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');
-
-      const baseUrl = new URL(url);
-      const listUrl = `${baseUrl.origin}${baseUrl.pathname.split('/episode-')[0]}/list?title_no=${titleId}`;
-      logger.log('info', 'Chargement de la liste des chapitres', { url: listUrl });
-      
-      await page.goto(listUrl, { waitUntil: 'networkidle0' });
-      await sleep(2000);
-
-      await page.waitForSelector('#_listUl li', { timeout: 10000 });
-
-      const totalPages = await page.evaluate(() => {
-        const pageElements = document.querySelectorAll('.paginate a');
-        const pages = Array.from(pageElements)
-          .map(el => parseInt(el.textContent || '0'))
-          .filter(num => !isNaN(num));
-        return pages.length > 0 ? Math.max(...pages) : 1;
-      });
-
-      logger.log('info', 'Pages trouvées', { totalPages });
-
-      const allChapters: ChapterData[] = [];
-
-      for (let currentPage = 1; currentPage <= totalPages; currentPage++) {
-        const pageUrl = `${listUrl}&page=${currentPage}`;
-        logger.log('info', 'Chargement de la page', { page: currentPage, totalPages });
-        
-        await page.goto(pageUrl, { waitUntil: 'networkidle0' });
-        await sleep(2000);
-
-        await page.waitForSelector('#_listUl li', { timeout: 10000 });
-
-        const chaptersOnPage = await page.evaluate(() => {
-          const items = document.querySelectorAll('#_listUl li');
-          return Array.from(items).map(item => {
-            const link = item.querySelector('a');
-            const titleElement = item.querySelector('.subj');
-            const dateElement = item.querySelector('.date');
-            const href = link?.getAttribute('href') || '';
-            const episodeMatch = href.match(/episode-(\d+)/);
-            const episodeNumber = episodeMatch ? episodeMatch[1] : '';
-            const idMatch = href.match(/episode_no=(\d+)/);
-            const id = idMatch ? idMatch[1] : episodeNumber;
-            const fullTitle = titleElement?.textContent?.trim() || '';
-            const titleMatch = fullTitle.match(/Episode\s+\d+(?:\s*-\s*(.+))?/);
-            const title = titleMatch?.[1]?.trim() || '';
-
-            return {
-              id,
-              chapter: `Episode ${episodeNumber}`,
-              title: title || null,
-              publishedAt: dateElement?.textContent?.trim() || null,
-              url: href,
-              source: 'webtoons'
-            };
-          });
-        });
-
-        allChapters.push(...chaptersOnPage);
-        logger.log('info', 'Chapitres trouvés sur la page', { 
-          page: currentPage, 
-          count: chaptersOnPage.length 
-        });
-      }
-
-      await page.close();
-      logger.log('info', 'Total des chapitres trouvés', { count: allChapters.length });
-
-      return {
-        chapters: allChapters.reverse(),
-        totalChapters: allChapters.length,
-        source: {
-          name: 'webtoons',
-          url: listUrl,
-          titleId: titleId
-        }
-      };
-
-    } catch (error) {
-      logger.log('error', 'Erreur lors du scraping des chapitres sur Webtoons', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue'
-      });
-      throw error;
-    }
-  }
-};
-
-const komgaSource: Source = {
-  name: 'komga',
-  baseUrl: process.env.KOMGA_URL || '',
-  search: async (title: string) => {
-    try {
-      if (!process.env.KOMGA_URL) {
-        return { titleId: null, url: null };
-      }
-      const searchUrl = `${process.env.KOMGA_URL.replace(/\/$/, '')}/api/v1/series?search=${encodeURIComponent(title)}`;
-      const res = await retry(() => fetch(searchUrl), 3, 1000);
-      if (!res.ok) return { titleId: null, url: null };
-      const data = await res.json();
-      const first = (data.content || [])[0];
-      if (!first) return { titleId: null, url: null };
-      return {
-        titleId: first.id,
-        url: `${process.env.KOMGA_URL.replace(/\/$/, '')}/series/${first.id}`
-      };
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la recherche sur Komga', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue'
-      });
-      return { titleId: null, url: null };
-    }
-  },
-  getChapters: async (titleId: string, url: string): Promise<ChaptersResult> => {
-    const komgaBaseUrl = process.env.KOMGA_URL;
-    if (!komgaBaseUrl) {
-      throw new Error('KOMGA_URL not configured');
-    }
-    try {
-      const chaptersUrl = `${komgaBaseUrl.replace(/\/$/, '')}/api/v1/series/${titleId}/books?size=1000`;
-      const res = await retry(() => fetch(chaptersUrl), 3, 1000);
-      if (!res.ok) throw new Error('Aucun chapitre trouvé');
-      const data = await res.json();
-      const chapters = (data.content || []).map((book: any) => ({
-        id: book.id,
-        chapter: book.metadata?.number ? `Chapitre ${book.metadata.number}` : book.name,
-        title: book.metadata?.title || null,
-        publishedAt: book.metadata?.releaseDate || null,
-        url: `${komgaBaseUrl.replace(/\/$/, '')}/book/${book.id}/read`,
-        source: 'komga'
-      }));
-      return {
-        chapters,
-        totalChapters: chapters.length,
-        source: { name: 'komga', url, titleId }
-      };
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la récupération des chapitres sur Komga', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue',
-        titleId
-      });
-      throw error;
-    }
-  }
-};
-
-
-// Source MangaScantrad
-const mangaScantradSource: Source = {
-  name: 'mangascantrad',
-  baseUrl: 'https://manga-scantrad.io',
-  search: async (title: string) => {
-    const { page } = await setupBrowser();
-    
-    try {
-      // Formater le titre pour l'URL directe
-      const formattedTitle = title.toLowerCase()
-        .replace(/boku no/i, 'my')
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-
-      // Essayer l'accès direct
-      const directUrl = `${mangaScantradSource.baseUrl}/manga/${formattedTitle}`;
-      logger.log('info', 'Tentative d\'accès direct', { 
-        title,
-        url: directUrl 
-      });
-
-      if (await bypassBlocker(page, directUrl)) {
-        // Vérifier si la page contient le contenu attendu
-        const pageContent = await page.evaluate(() => {
-          const title = document.querySelector('.manga-title, .series-title')?.textContent?.trim();
-          const chapters = document.querySelector('.chapter-list, .chapters-list');
-          return { title, hasChapters: !!chapters };
-        });
-
-        if (pageContent.hasChapters) {
-          logger.log('info', 'Page manga trouvée directement', { 
-            url: directUrl,
-            title: pageContent.title 
-          });
-          return { titleId: formattedTitle, url: directUrl };
-        }
-      }
-
-      // Si l'accès direct échoue, essayer la recherche
-      const searchUrl = `${mangaScantradSource.baseUrl}/search?query=${encodeURIComponent(title)}`;
-      logger.log('info', 'Tentative de recherche', { url: searchUrl });
-
-      if (await bypassBlocker(page, searchUrl)) {
-        // Attendre que les résultats se chargent
-        await sleep(3000);
-
-        const searchResult = await page.evaluate((searchTitle) => {
-          const normalizeString = (str: string) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
-          const searchNormalized = normalizeString(searchTitle);
-          
-          const results = Array.from(document.querySelectorAll('.manga-card, .search-result'));
-          for (const result of results) {
-            const link = result.querySelector('a');
-            const title = result.querySelector('.manga-title, .title')?.textContent?.trim();
-            
-            if (link?.href && title) {
-              const titleNormalized = normalizeString(title);
-              // Vérifier si les titres correspondent approximativement
-              if (titleNormalized.includes(searchNormalized) || 
-                  searchNormalized.includes(titleNormalized)) {
-                return { url: link.href, title };
-              }
-            }
-          }
-          return null;
-        }, title);
-
-        if (searchResult) {
-          logger.log('info', 'Manga trouvé via recherche', searchResult);
-          const titleId = searchResult.url.split('/manga/')[1]?.replace(/\/$/, '');
-          return { titleId, url: searchResult.url };
-        }
-      }
-
-      logger.log('info', 'Manga non trouvé sur MangaScantrad', { query: title });
-      return { titleId: null, url: null };
-
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la recherche sur MangaScantrad', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue',
-        stack: error instanceof Error ? error.stack : undefined
-      });
-      return { titleId: null, url: null };
-    } finally {
-      await page.close();
-    }
-  },
-  getChapters: async (titleId: string, url: string): Promise<ChaptersResult> => {
-    const { page } = await setupBrowser();
-    
-    try {
-      logger.log('debug', 'Tentative d\'accès à la page des chapitres', { url });
-
-      if (!await bypassBlocker(page, url)) {
-        throw new Error('Impossible d\'accéder à la page des chapitres');
-      }
-
-      // Attendre que le contenu se charge
-      await sleep(3000);
-
-      // Vérifier la présence des chapitres avec différents sélecteurs
-      const hasChapters = await page.evaluate(() => {
-        const selectors = [
-          '.chapter-list', 
-          '.chapters-list',
-          '.manga-chapters',
-          '[class*="chapter"]'
-        ];
-        return selectors.some(selector => document.querySelector(selector));
-      });
-
-      if (!hasChapters) {
-        logger.log('error', 'Aucune liste de chapitres trouvée', { url });
-        throw new Error('Liste des chapitres non trouvée');
-      }
-
-      const chapters = await page.evaluate(() => {
-        // Fonction pour extraire le numéro de chapitre
-        const extractChapterNumber = (text: string) => {
-          const match = text.match(/(?:chapitre|chapter|ch[.]?)\s*(\d+(?:\.\d+)?)/i);
-          return match ? match[1] : null;
-        };
-
-        // Trouver tous les éléments qui pourraient être des chapitres
-        const chapterElements = Array.from(document.querySelectorAll(
-          '.chapter-item, .chapter-element, .chapter, [class*="chapter"]'
-        ));
-
-        return chapterElements.map(item => {
-          const link = item.querySelector('a');
-          const href = link?.getAttribute('href') || '';
-          
-          // Essayer d'extraire le numéro de chapitre de différentes manières
-          let chapterNumber = null;
-          
-          // 1. Depuis l'URL
-          const urlMatch = href.match(/(?:chapitre|chapter|ch)-(\d+(?:\.\d+)?)/i);
-          if (urlMatch) chapterNumber = urlMatch[1];
-          
-          // 2. Depuis le texte du lien
-          if (!chapterNumber && link) {
-            chapterNumber = extractChapterNumber(link.textContent || '');
-          }
-          
-          // 3. Depuis le texte de l'élément
-          if (!chapterNumber) {
-            chapterNumber = extractChapterNumber(item.textContent || '');
-          }
-
-          // Extraire le titre si disponible
-          const titleElement = item.querySelector('.chapter-title, .title') || 
-                             link?.querySelector('.title') ||
-                             item.querySelector('span:not(.number)');
-          
-          const title = titleElement?.textContent?.trim() || null;
-
-          // Extraire la date
-          const dateElement = item.querySelector('.chapter-date, .date, time');
-          const publishedAt = dateElement?.textContent?.trim() || null;
-
-          return {
-            id: chapterNumber || href.split('/').pop() || '',
-            chapter: chapterNumber ? `Chapitre ${chapterNumber}` : 'Chapitre inconnu',
-            title,
-            publishedAt,
-            url: href.startsWith('http') ? href : `https://manga-scantrad.io${href}`,
-            source: 'mangascantrad'
-          };
-        }).filter(chapter => chapter.id && chapter.url);
-      });
-
-      if (chapters.length === 0) {
-        logger.log('warning', 'Aucun chapitre extrait', { url });
-        throw new Error('Aucun chapitre trouvé');
-      }
-
-      logger.log('info', 'Chapitres extraits avec succès', {
-        url,
-        chaptersCount: chapters.length,
-        firstChapter: chapters[0],
-        lastChapter: chapters[chapters.length - 1]
-      });
-
-      return {
-        chapters: chapters.reverse(), // Du plus récent au plus ancien
-        totalChapters: chapters.length,
-        source: {
-          name: 'mangascantrad',
-          url: url,
-          titleId: titleId
-        }
-      };
-
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la récupération des chapitres', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue',
-        stack: error instanceof Error ? error.stack : undefined,
-        url
-      });
-      throw error;
-    } finally {
-      await page.close();
-    }
-  }
-};
-
-// Source MangaDex
-const mangadexSource: Source = {
-  name: 'mangadex',
-  baseUrl: 'https://api.mangadex.org',
-  search: async (title: string) => {
-    try {
-      logger.log('info', 'Recherche sur MangaDex API', { query: title });
-      
-      const searchUrl = `${mangadexSource.baseUrl}/manga?title=${encodeURIComponent(title)}&limit=5&order[relevance]=desc`;
-      const response = await retry(() => fetch(searchUrl), 3, 1000);
-      const data = await response.json();
-
-      if (!response.ok || !data.data?.length) {
-        logger.log('info', 'Manga non trouvé sur MangaDex', { query: title });
-        return { titleId: null, url: null };
-      }
-
-      // Trouver le meilleur résultat
-      const bestMatch = data.data[0];
-      const titleId = bestMatch.id;
-      const url = `https://mangadex.org/title/${titleId}`;
-
-      logger.log('info', 'Manga trouvé sur MangaDex', {
-        titleId,
-        url,
-        title: bestMatch.attributes.title
-      });
-
-      return { titleId, url };
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la recherche sur MangaDex', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue'
-      });
-      return { titleId: null, url: null };
-    }
-  },
-  getChapters: async (titleId: string, url: string): Promise<ChaptersResult> => {
-    try {
-      logger.log('info', 'Récupération des chapitres depuis MangaDex', { titleId, url });
-
-      // Récupérer les chapitres avec pagination
-      const chaptersUrl = `${mangadexSource.baseUrl}/manga/${titleId}/feed?translatedLanguage[]=fr&translatedLanguage[]=en&order[chapter]=desc&limit=500`;
-      const response = await retry(() => fetch(chaptersUrl), 3, 1000);
-      const data: MangaDexChaptersResponse = await response.json();
-
-      if (!response.ok || !data.data?.length) {
-        throw new Error('Aucun chapitre trouvé');
-      }
-
-      const chapters = data.data.map((chapter: MangaDexChapter) => ({
-        id: chapter.id,
-        chapter: `Chapitre ${chapter.attributes.chapter || 'inconnu'}`,
-        title: chapter.attributes.title || null,
-        publishedAt: chapter.attributes.publishAt || null,
-        url: `https://mangadex.org/chapter/${chapter.id}`,
-        source: 'mangadex',
-        language: chapter.attributes.translatedLanguage
-      }));
-
-      logger.log('info', 'Chapitres récupérés avec succès', {
-        chaptersCount: chapters.length,
-        firstChapter: chapters[0],
-        lastChapter: chapters[chapters.length - 1]
-      });
-
-      return {
-        chapters,
-        totalChapters: chapters.length,
-        source: {
-          name: 'mangadx',
-          url: url,
-          titleId: titleId
-        }
-      };
-
-    } catch (error) {
-      logger.log('error', 'Erreur lors de la récupération des chapitres sur MangaDex', {
-        error: error instanceof Error ? error.message : 'Erreur inconnue',
-        titleId
-      });
-      throw error;
-    }
-  }
-};
-
-// Liste des sources disponibles
 const sources: Source[] = [
   mangadexSource,
-  webtoonSource,
+  webtoonsSource,
   komgaSource,
-  toomicsSource
-  // Retrait temporaire de mangaScantrad à cause de Cloudflare
+  toomicsSource,
   // mangaScantradSource
 ];
 
-// Modifier la fonction searchAllSources pour utiliser les types corrects
 async function searchAllSources(mangaTitle: string): Promise<SourceSearchResult[]> {
   const searchPromises = sources.map(async (source) => {
     try {
       logger.log('info', `Recherche sur ${source.name}`, { query: mangaTitle });
       const result = await source.search(mangaTitle);
       if (result.titleId && result.url) {
-        return {
-          source: source.name,
-          titleId: result.titleId,
-          url: result.url,
-          sourceObj: source
-        };
+        return { source: source.name, titleId: result.titleId, url: result.url, sourceObj: source } as SourceSearchResult;
       }
       return null;
     } catch (error) {
@@ -826,158 +35,68 @@ async function searchAllSources(mangaTitle: string): Promise<SourceSearchResult[
       return null;
     }
   });
-
   const results = await Promise.all(searchPromises);
-  return results.filter((result): result is SourceSearchResult => result !== null);
+  return results.filter((r): r is SourceSearchResult => r !== null);
 }
 
-async function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-export async function GET(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
+export async function GET(request: Request, { params }: { params: { id: string } }) {
   const startTime = Date.now();
-
-  // Extraire l'ID du manga de manière sûre
-  const { id: mangaId } = await Promise.resolve(params);
+  const { id: mangaId } = params;
   if (!mangaId) {
     logger.log('warning', 'Requête invalide - ID manga manquant');
-    return NextResponse.json(
-      { error: 'ID du manga manquant' },
-      { status: 400 }
-    );
+    return NextResponse.json({ error: 'ID du manga manquant' }, { status: 400 });
   }
-
   try {
-    logger.log('info', 'Début de la requête GET chapters', {
-      mangaId,
-      timestamp: new Date().toISOString()
-    });
-
-    // Récupérer les paramètres de pagination depuis l'URL
+    logger.log('info', 'Début de la requête GET chapters', { mangaId, timestamp: new Date().toISOString() });
     const { searchParams } = new URL(request.url);
     const page = Math.max(1, parseInt(searchParams.get('page') || '1'));
     const limit = Math.max(1, parseInt(searchParams.get('limit') || '10'));
     const getAll = searchParams.get('all') === 'true';
     const sortBy = searchParams.get('sort') || 'chapter-asc';
 
-    logger.log('debug', 'Paramètres de pagination', {
-      page,
-      limit,
-      mangaId
-    });
-
-    // Vérifier le cache
     const cacheKey = `chapters_${mangaId}`;
     const cachedData = await chaptersCache.get(cacheKey);
-    
     if (cachedData) {
-      logger.log('info', 'Données trouvées en cache', {
-        mangaId,
-        chaptersCount: cachedData.chapters.length
-      });
-      
-      // Si on demande tous les chapitres, retourner sans pagination mais avec tri
+      logger.log('info', 'Données trouvées en cache', { mangaId, chaptersCount: cachedData.chapters.length });
       if (getAll) {
         const sortedChapters = sortChapters(cachedData.chapters, sortBy);
-        return NextResponse.json({
-          chapters: sortedChapters,
-          totalChapters: cachedData.totalChapters,
-          source: cachedData.source
-        });
+        return NextResponse.json({ chapters: sortedChapters, totalChapters: cachedData.totalChapters, source: cachedData.source });
       }
-      
       return formatResponse(cachedData, page, limit, sortBy);
     }
 
-    logger.log('debug', 'Récupération des informations depuis MangaDex', {
-      mangaId
-    });
-
-    // Récupérer les infos du manga depuis MangaDex
-    const mangaResponse = await retry(
-      () =>
-        fetch(
-          `https://api.mangadex.org/manga/${mangaId}?includes[]=title`
-        ),
-      3,
-      1000,
-    );
+    const mangaResponse = await retry(() => fetch(`https://api.mangadex.org/manga/${mangaId}?includes[]=title`), 3, 1000);
     const mangaData = await mangaResponse.json();
-    
     if (!mangaResponse.ok) {
-      logger.log('error', 'Erreur MangaDex API', {
-        status: mangaResponse.status,
-        statusText: mangaResponse.statusText,
-        mangaId,
-        response: mangaData
-      });
-      return NextResponse.json(
-        { error: 'Manga non trouvé' },
-        { status: 404 }
-      );
+      logger.log('error', 'Erreur MangaDex API', { status: mangaResponse.status, statusText: mangaResponse.statusText, mangaId, response: mangaData });
+      return NextResponse.json({ error: 'Manga non trouvé' }, { status: 404 });
     }
-
-    const mangaTitle = mangaData.data.attributes.title.en || 
+    const mangaTitle = mangaData.data.attributes.title.en ||
                       mangaData.data.attributes.title.fr ||
-                      mangaData.data.attributes.title.ja || 
+                      mangaData.data.attributes.title.ja ||
                       Object.values(mangaData.data.attributes.title)[0];
 
-    logger.log('info', 'Titre du manga récupéré', {
-      mangaId,
-      title: mangaTitle,
-      availableLanguages: Object.keys(mangaData.data.attributes.title)
-    });
-
-    // Rechercher sur toutes les sources
+    logger.log('info', 'Titre du manga récupéré', { mangaId, title: mangaTitle, availableLanguages: Object.keys(mangaData.data.attributes.title) });
     const sourceResults = await searchAllSources(mangaTitle);
-    
     logger.log('debug', 'Résultats de la recherche sur les sources', {
       mangaId,
       title: mangaTitle,
-      sourceResults: sourceResults.map(r => ({
-        source: r.source,
-        titleId: r.titleId,
-        url: r.url
-      }))
+      sourceResults: sourceResults.map(r => ({ source: r.source, titleId: r.titleId, url: r.url }))
     });
-
     if (sourceResults.length === 0) {
-      logger.log('warning', 'Aucune source trouvée', {
-        mangaId,
-        title: mangaTitle
-      });
-      return NextResponse.json(
-        { error: 'Manga non trouvé sur aucune source disponible' },
-        { status: 404 }
-      );
-    }    logger.log('info', 'Récupération des chapitres en parallèle', {
-      source: sourceResults.map(r => r.source).join(', ')
-    });
-
-    const chapterPromises = sourceResults.map(r =>
-      r.sourceObj.getChapters(r.titleId, r.url).then(data => ({
-        ...data,
-        source: { name: r.source, url: r.url, titleId: r.titleId }
-      }))
-    );
-
+      logger.log('warning', 'Aucune source trouvée', { mangaId, title: mangaTitle });
+      return NextResponse.json({ error: 'Manga non trouvé sur aucune source disponible' }, { status: 404 });
+    }
+    logger.log('info', 'Récupération des chapitres en parallèle', { source: sourceResults.map(r => r.source).join(', ') });
+    const chapterPromises = sourceResults.map(r => r.sourceObj.getChapters(r.titleId, r.url).then(data => ({ ...data, source: { name: r.source, url: r.url, titleId: r.titleId } })));
     let resultData: { chapters: ChapterData[]; totalChapters: number; source: SourceInfo };
     try {
       resultData = await Promise.any(chapterPromises);
     } catch {
       logger.log('error', 'Échec de toutes les sources', { mangaId });
-      return NextResponse.json(
-        { error: 'Aucune source valide' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Aucune source valide' }, { status: 500 });
     }
-
     const { chapters: allChapters, totalChapters, source } = resultData;
-
     logger.log('info', 'Chapitres récupérés avec succès', {
       source: source.name,
       chaptersCount: allChapters.length,
@@ -985,60 +104,26 @@ export async function GET(
       firstChapter: allChapters[0],
       lastChapter: allChapters[allChapters.length - 1]
     });
-
-    // Sauvegarder dans le cache
-    const cachePayload = {
-      chapters: allChapters,
-      totalChapters,
-      source
-    };
-
+    const cachePayload = { chapters: allChapters, totalChapters, source };
     await chaptersCache.set(cacheKey, cachePayload);
-    logger.log('debug', 'Données mises en cache', {
-      mangaId,
-      cacheKey
-    });
-
-    // Si on demande tous les chapitres, retourner sans pagination mais avec tri
+    logger.log('debug', 'Données mises en cache', { mangaId, cacheKey });
     if (getAll) {
       const sortedChapters = sortChapters(allChapters, sortBy);
-      return NextResponse.json({
-        chapters: sortedChapters,
-        totalChapters,
-        source
-      });
+      return NextResponse.json({ chapters: sortedChapters, totalChapters, source });
     }
-
     const response = formatResponse(cachePayload, page, limit, sortBy);
     const executionTime = Date.now() - startTime;
-    
-    logger.log('info', 'Requête terminée avec succès', {
-      mangaId,
-      executionTime,
-      chaptersCount: allChapters.length,
-      page,
-      limit
-    });
-
+    logger.log('info', 'Requête terminée avec succès', { mangaId, executionTime, chaptersCount: allChapters.length, page, limit });
     return response;
-
   } catch (error) {
     const executionTime = Date.now() - startTime;
-    // Éviter de logger params directement
     logger.log('error', 'Erreur lors de la récupération des chapitres', {
       error: error instanceof Error ? error.message : 'Erreur inconnue',
       stack: error instanceof Error ? error.stack : undefined,
       executionTime,
-      mangaId // Utiliser uniquement l'ID
+      mangaId
     });
-    
-    return NextResponse.json(
-      { 
-        error: 'Erreur serveur lors de la récupération des chapitres',
-        details: error instanceof Error ? error.message : 'Erreur inconnue'
-      },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Erreur serveur lors de la récupération des chapitres', details: error instanceof Error ? error.message : 'Erreur inconnue' }, { status: 500 });
   }
 }
 
@@ -1059,19 +144,11 @@ function sortChapters(chapters: ChapterData[], sortBy: string = 'chapter-asc'): 
       });
     case 'chapter-desc':
       return sorted.sort((a, b) => {
-        // Extraire les numéros de chapitre plus intelligemment
-        const aChapterText = a.chapter || '';
-        const bChapterText = b.chapter || '';
-        
-        const aNum = parseFloat(aChapterText.replace(/[^\d.]/g, ''));
-        const bNum = parseFloat(bChapterText.replace(/[^\d.]/g, ''));
-        
-        // Si on a des numéros valides, trier par numéro (décroissant)
+        const aNum = parseFloat((a.chapter || '').replace(/[^\d.]/g, ''));
+        const bNum = parseFloat((b.chapter || '').replace(/[^\d.]/g, ''));
         if (!isNaN(aNum) && !isNaN(bNum)) {
           return bNum - aNum;
         }
-        
-        // Fallback : tri par date (plus récent en premier)
         const dateA = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
         const dateB = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
         return dateB - dateA;
@@ -1079,19 +156,11 @@ function sortChapters(chapters: ChapterData[], sortBy: string = 'chapter-asc'): 
     case 'chapter-asc':
     default:
       return sorted.sort((a, b) => {
-        // Extraire les numéros de chapitre plus intelligemment
-        const aChapterText = a.chapter || '';
-        const bChapterText = b.chapter || '';
-        
-        const aNum = parseFloat(aChapterText.replace(/[^\d.]/g, ''));
-        const bNum = parseFloat(bChapterText.replace(/[^\d.]/g, ''));
-        
-        // Si on a des numéros valides, trier par numéro
+        const aNum = parseFloat((a.chapter || '').replace(/[^\d.]/g, ''));
+        const bNum = parseFloat((b.chapter || '').replace(/[^\d.]/g, ''));
         if (!isNaN(aNum) && !isNaN(bNum)) {
           return aNum - bNum;
         }
-        
-        // Fallback : tri par date (plus ancien en premier)
         const dateA = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
         const dateB = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
         return dateA - dateB;
@@ -1106,20 +175,11 @@ function formatResponse(
   sortBy: string = 'chapter-asc'
 ) {
   const { chapters: allChapters, totalChapters, source } = data;
-  
-  // Trier AVANT la pagination
   const sortedChapters = sortChapters(allChapters, sortBy);
-  
-  // Calculer les indices pour la pagination
   const startIndex = (page - 1) * limit;
   const endIndex = startIndex + limit;
-  
-  // Extraire les chapitres pour la page courante
   const paginatedChapters = sortedChapters.slice(startIndex, endIndex);
-
-  // Calculer le nombre total de pages
   const totalPages = Math.ceil(totalChapters / limit);
-
   return NextResponse.json({
     chapters: paginatedChapters,
     pagination: {
@@ -1132,4 +192,4 @@ function formatResponse(
     },
     source
   });
-} 
+}

--- a/app/services/sources/index.ts
+++ b/app/services/sources/index.ts
@@ -1,20 +1,24 @@
 import { Source } from '@/app/types/source';
 import toomicsSource from './toomics';
+import webtoonsSource from './webtoons';
+import komgaSource from './komga';
+import mangadexSource from './mangadex';
+import mangaScantradSource from './mangaScantrad';
 
-// Exportation de toutes les sources disponibles
 export const sources: Record<string, Source> = {
   toomics: toomicsSource,
+  webtoons: webtoonsSource,
+  komga: komgaSource,
+  mangadex: mangadexSource,
+  mangascantrad: mangaScantradSource,
 };
 
-// Exportation individuelle des sources
-export { toomicsSource };
+export { toomicsSource, webtoonsSource, komgaSource, mangadexSource, mangaScantradSource };
 
-// Fonction utilitaire pour obtenir toutes les sources
 export function getAllSources(): Source[] {
   return Object.values(sources);
 }
 
-// Fonction utilitaire pour obtenir une source par son nom
 export function getSource(name: string): Source | undefined {
   return sources[name];
 }

--- a/app/services/sources/komga.ts
+++ b/app/services/sources/komga.ts
@@ -1,0 +1,63 @@
+import { Source, ChaptersResult } from '@/app/types/source';
+import { logger } from '@/app/utils/logger';
+import { retry } from '@/app/utils/retry';
+
+export const komgaSource: Source = {
+  name: 'komga',
+  baseUrl: process.env.KOMGA_URL || '',
+  async search(title: string) {
+    try {
+      if (!process.env.KOMGA_URL) {
+        return { titleId: null, url: null };
+      }
+      const searchUrl = `${process.env.KOMGA_URL.replace(/\/$/, '')}/api/v1/series?search=${encodeURIComponent(title)}`;
+      const res = await retry(() => fetch(searchUrl), 3, 1000);
+      if (!res.ok) return { titleId: null, url: null };
+      const data = await res.json();
+      const first = (data.content || [])[0];
+      if (!first) return { titleId: null, url: null };
+      return {
+        titleId: first.id,
+        url: `${process.env.KOMGA_URL.replace(/\/$/, '')}/series/${first.id}`
+      };
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la recherche sur Komga', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue'
+      });
+      return { titleId: null, url: null };
+    }
+  },
+  async getChapters(titleId: string, url: string): Promise<ChaptersResult> {
+    const komgaBaseUrl = process.env.KOMGA_URL;
+    if (!komgaBaseUrl) {
+      throw new Error('KOMGA_URL not configured');
+    }
+    try {
+      const chaptersUrl = `${komgaBaseUrl.replace(/\/$/, '')}/api/v1/series/${titleId}/books?size=1000`;
+      const res = await retry(() => fetch(chaptersUrl), 3, 1000);
+      if (!res.ok) throw new Error('Aucun chapitre trouvé');
+      const data = await res.json();
+      const chapters = (data.content || []).map((book: any) => ({
+        id: book.id,
+        chapter: book.metadata?.number ? `Chapitre ${book.metadata.number}` : book.name,
+        title: book.metadata?.title || null,
+        publishedAt: book.metadata?.releaseDate || null,
+        url: `${komgaBaseUrl.replace(/\/$/, '')}/book/${book.id}/read`,
+        source: 'komga'
+      }));
+      return {
+        chapters,
+        totalChapters: chapters.length,
+        source: { name: 'komga', url, titleId }
+      };
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la récupération des chapitres sur Komga', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
+        titleId
+      });
+      throw error;
+    }
+  }
+};
+
+export default komgaSource;

--- a/app/services/sources/mangaScantrad.ts
+++ b/app/services/sources/mangaScantrad.ts
@@ -1,0 +1,316 @@
+import type { Browser, Page } from 'puppeteer';
+import { Source, ChaptersResult, ChapterData } from '@/app/types/source';
+import { launchBrowser } from '@/app/utils/launchBrowser';
+import { logger } from '@/app/utils/logger';
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+let browserPromise: Promise<Browser> | null = null;
+async function getBrowser(): Promise<Browser> {
+  if (!browserPromise) {
+    browserPromise = launchBrowser({
+      headless: false,
+      args: [
+        '--disable-accelerated-2d-canvas',
+        '--disable-gpu',
+        '--window-size=1920x1080',
+        '--disable-features=IsolateOrigins,site-per-process',
+        '--disable-blink-features=AutomationControlled'
+      ],
+      defaultViewport: null
+    });
+  }
+  return browserPromise;
+}
+
+async function setupBrowser() {
+  const browser = await getBrowser();
+  const page = await browser.newPage();
+  await page.evaluateOnNewDocument(() => {
+    delete Object.getPrototypeOf(navigator).webdriver;
+    // @ts-expect-error -- navigator.chrome is not a standard property
+    window.navigator.chrome = { runtime: {} };
+    Object.defineProperty(navigator, 'languages', { get: () => ['fr-FR', 'fr', 'en-US', 'en'] });
+    Object.defineProperty(navigator, 'plugins', {
+      get: () => [{
+        0: { type: 'application/x-google-chrome-pdf' },
+        description: 'Portable Document Format',
+        filename: 'internal-pdf-viewer',
+        length: 1,
+        name: 'Chrome PDF Plugin'
+      }]
+    });
+  });
+  await page.setExtraHTTPHeaders({
+    'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Connection': 'keep-alive',
+    'Cache-Control': 'max-age=0',
+    'sec-ch-ua': '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"Windows"',
+    'Upgrade-Insecure-Requests': '1',
+    'Sec-Fetch-Site': 'none',
+    'Sec-Fetch-Mode': 'navigate',
+    'Sec-Fetch-User': '?1',
+    'Sec-Fetch-Dest': 'document'
+  });
+  await page.setViewport({ width: 1920, height: 1080 });
+  return { browser, page };
+}
+
+async function handleCloudflare(page: Page): Promise<boolean> {
+  try {
+    logger.log('info', 'Tentative de contournement de Cloudflare');
+    await page.waitForFunction(() => {
+      return document.querySelector('#challenge-form') !== null ||
+             document.querySelector('#cf-challenge-running') !== null ||
+             document.querySelector('#cf-spinner') !== null;
+    }, { timeout: 5000 }).catch(() => null);
+    await sleep(2000);
+    for (let i = 0; i < 5; i++) {
+      const x = Math.floor(Math.random() * 1000);
+      const y = Math.floor(Math.random() * 1000);
+      await page.mouse.move(x, y);
+      await sleep(500);
+    }
+    await Promise.race([
+      page.waitForFunction(() => {
+        return document.querySelector('#challenge-form') === null &&
+               document.querySelector('#cf-challenge-running') === null &&
+               document.querySelector('#cf-spinner') === null;
+      }, { timeout: 30000 }),
+      page.waitForNavigation({ timeout: 30000, waitUntil: 'networkidle0' })
+    ]);
+    const content = await page.content();
+    if (content.includes('cf-browser-verification') ||
+        content.includes('cf-challenge-running') ||
+        content.includes('_cf_chl_opt')) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    logger.log('error', 'Erreur lors du contournement de Cloudflare', {
+      error: error instanceof Error ? error.message : 'Erreur inconnue'
+    });
+    return false;
+  }
+}
+
+async function bypassBlocker(page: Page, url: string, maxRetries = 3): Promise<boolean> {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      logger.log('info', 'Tentative de contournement du blocage', {
+        attempt: i + 1,
+        maxRetries,
+        url
+      });
+      const delay = Math.floor(Math.random() * 5000) + 5000;
+      await sleep(delay);
+      await page.goto(url, {
+        waitUntil: 'networkidle0',
+        timeout: 60000
+      });
+      const isCloudflare = await page.evaluate(() => {
+        return document.body.textContent?.toLowerCase().includes('cloudflare') ||
+               document.querySelector('#challenge-form, #cf-challenge-running, #cf-spinner') !== null;
+      });
+      if (isCloudflare) {
+        logger.log('info', 'Détection de Cloudflare, tentative de contournement');
+        const cloudflareBypass = await handleCloudflare(page);
+        if (!cloudflareBypass) {
+          logger.log('warning', 'Échec du contournement de Cloudflare');
+          continue;
+        }
+      }
+      const pageStatus = await page.evaluate(() => {
+        const selectors = {
+          validContent: '.manga-title, .chapter-list, .manga-info, .search-results, .chapters-list',
+          errorIndicators: {
+            error404: '.error-404, .not-found',
+            blocked: '.blocked-message, .block-message',
+            captcha: '#captcha, .captcha, .g-recaptcha',
+            cloudflare: '#challenge-form, #cf-challenge-running'
+          }
+        } as const;
+        const hasValidContent = !!document.querySelector(selectors.validContent);
+        const errors = Object.entries(selectors.errorIndicators).reduce((acc, [key, selector]) => {
+          acc[key as keyof typeof selectors.errorIndicators] = !!document.querySelector(selector);
+          return acc;
+        }, {} as Record<string, boolean>);
+        return { hasValidContent, errors };
+      });
+      if (pageStatus.hasValidContent) {
+        logger.log('info', 'Contournement réussi', {
+          attempt: i + 1,
+          url
+        });
+        return true;
+      }
+      logger.log('warning', 'Page invalide, nouvelle tentative', {
+        attempt: i + 1,
+        url,
+        pageStatus
+      });
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la tentative de contournement', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
+        attempt: i + 1,
+        url
+      });
+    }
+  }
+  return false;
+}
+
+export const mangaScantradSource: Source = {
+  name: 'mangascantrad',
+  baseUrl: 'https://manga-scantrad.io',
+  async search(title: string) {
+    const { page } = await setupBrowser();
+    try {
+      const formattedTitle = title.toLowerCase()
+        .replace(/boku no/i, 'my')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      const directUrl = `${mangaScantradSource.baseUrl}/manga/${formattedTitle}`;
+      logger.log('info', "Tentative d'accès direct", { title, url: directUrl });
+      if (await bypassBlocker(page, directUrl)) {
+        const pageContent = await page.evaluate(() => {
+          const titleEl = document.querySelector('.manga-title, .series-title');
+          const chapters = document.querySelector('.chapter-list, .chapters-list');
+          return { title: titleEl?.textContent?.trim(), hasChapters: !!chapters };
+        });
+        if (pageContent.hasChapters) {
+          logger.log('info', 'Page manga trouvée directement', {
+            url: directUrl,
+            title: pageContent.title
+          });
+          return { titleId: formattedTitle, url: directUrl };
+        }
+      }
+      const searchUrl = `${mangaScantradSource.baseUrl}/search?query=${encodeURIComponent(title)}`;
+      logger.log('info', 'Tentative de recherche', { url: searchUrl });
+      if (await bypassBlocker(page, searchUrl)) {
+        await sleep(3000);
+        const searchResult = await page.evaluate((searchTitle) => {
+          const normalizeString = (str: string) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
+          const searchNormalized = normalizeString(searchTitle);
+          const results = Array.from(document.querySelectorAll('.manga-card, .search-result'));
+          for (const result of results) {
+            const link = result.querySelector('a');
+            const titleEl = result.querySelector('.manga-title, .title') as HTMLElement | null;
+            const title = titleEl?.textContent?.trim();
+            if (link?.href && title) {
+              const titleNormalized = normalizeString(title);
+              if (titleNormalized.includes(searchNormalized) || searchNormalized.includes(titleNormalized)) {
+                return { url: link.href, title };
+              }
+            }
+          }
+          return null;
+        }, title);
+        if (searchResult) {
+          logger.log('info', 'Manga trouvé via recherche', searchResult);
+          const titleId = searchResult.url.split('/manga/')[1]?.replace(/\/$/, '');
+          return { titleId, url: searchResult.url };
+        }
+      }
+      logger.log('info', 'Manga non trouvé sur MangaScantrad', { query: title });
+      return { titleId: null, url: null };
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la recherche sur MangaScantrad', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
+        stack: error instanceof Error ? error.stack : undefined
+      });
+      return { titleId: null, url: null };
+    } finally {
+      await page.close();
+    }
+  },
+  async getChapters(titleId: string, url: string): Promise<ChaptersResult> {
+    const { page } = await setupBrowser();
+    try {
+      logger.log('debug', "Tentative d'accès à la page des chapitres", { url });
+      if (!await bypassBlocker(page, url)) {
+        throw new Error("Impossible d'accéder à la page des chapitres");
+      }
+      await sleep(3000);
+      const hasChapters = await page.evaluate(() => {
+        const selectors = ['.chapter-list', '.chapters-list', '.manga-chapters', '[class*="chapter"]'];
+        return selectors.some(selector => document.querySelector(selector));
+      });
+      if (!hasChapters) {
+        logger.log('error', 'Aucune liste de chapitres trouvée', { url });
+        throw new Error('Liste des chapitres non trouvée');
+      }
+      const chapters = await page.evaluate(() => {
+        const extractChapterNumber = (text: string) => {
+          const match = text.match(/(?:chapitre|chapter|ch[.]?)\s*(\d+(?:\.\d+)?)/i);
+          return match ? match[1] : null;
+        };
+        const chapterElements = Array.from(document.querySelectorAll('.chapter-item, .chapter-element, .chapter, [class*="chapter"]'));
+        return chapterElements.map(item => {
+          const link = item.querySelector('a');
+          const href = link?.getAttribute('href') || '';
+          let chapterNumber: string | null = null;
+          const urlMatch = href.match(/(?:chapitre|chapter|ch)-(\d+(?:\.\d+)?)/i);
+          if (urlMatch) chapterNumber = urlMatch[1];
+          if (!chapterNumber && link) {
+            chapterNumber = extractChapterNumber(link.textContent || '');
+          }
+          if (!chapterNumber) {
+            chapterNumber = extractChapterNumber(item.textContent || '');
+          }
+          const titleElement = item.querySelector('.chapter-title, .title') ||
+                               link?.querySelector('.title') ||
+                               item.querySelector('span:not(.number)');
+          const title = titleElement?.textContent?.trim() || null;
+          const dateElement = item.querySelector('.chapter-date, .date, time');
+          const publishedAt = dateElement?.textContent?.trim() || null;
+          return {
+            id: chapterNumber || href.split('/').pop() || '',
+            chapter: chapterNumber ? `Chapitre ${chapterNumber}` : 'Chapitre inconnu',
+            title,
+            publishedAt,
+            url: href.startsWith('http') ? href : `https://manga-scantrad.io${href}`,
+            source: 'mangascantrad'
+          } as ChapterData;
+        }).filter(ch => ch.id && ch.url);
+      });
+      if (chapters.length === 0) {
+        logger.log('warning', 'Aucun chapitre extrait', { url });
+        throw new Error('Aucun chapitre trouvé');
+      }
+      logger.log('info', 'Chapitres extraits avec succès', {
+        url,
+        chaptersCount: chapters.length,
+        firstChapter: chapters[0],
+        lastChapter: chapters[chapters.length - 1]
+      });
+      return {
+        chapters: chapters.reverse(),
+        totalChapters: chapters.length,
+        source: {
+          name: 'mangascantrad',
+          url,
+          titleId
+        }
+      };
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la récupération des chapitres', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
+        stack: error instanceof Error ? error.stack : undefined,
+        url
+      });
+      throw error;
+    } finally {
+      await page.close();
+    }
+  }
+};
+
+export default mangaScantradSource;

--- a/app/services/sources/mangadex.ts
+++ b/app/services/sources/mangadex.ts
@@ -1,0 +1,77 @@
+import { Source, ChaptersResult, ChapterData } from '@/app/types/source';
+import type { MangaDexChapter, MangaDexChaptersResponse } from '@/app/types/mangadex';
+import { logger } from '@/app/utils/logger';
+import { retry } from '@/app/utils/retry';
+
+export const mangadexSource: Source = {
+  name: 'mangadex',
+  baseUrl: 'https://api.mangadex.org',
+  async search(title: string) {
+    try {
+      logger.log('info', 'Recherche sur MangaDex API', { query: title });
+      const searchUrl = `${mangadexSource.baseUrl}/manga?title=${encodeURIComponent(title)}&limit=5&order[relevance]=desc`;
+      const response = await retry(() => fetch(searchUrl), 3, 1000);
+      const data = await response.json();
+      if (!response.ok || !data.data?.length) {
+        logger.log('info', 'Manga non trouvé sur MangaDex', { query: title });
+        return { titleId: null, url: null };
+      }
+      const bestMatch = data.data[0];
+      const titleId = bestMatch.id;
+      const url = `https://mangadex.org/title/${titleId}`;
+      logger.log('info', 'Manga trouvé sur MangaDex', {
+        titleId,
+        url,
+        title: bestMatch.attributes.title
+      });
+      return { titleId, url };
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la recherche sur MangaDex', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue'
+      });
+      return { titleId: null, url: null };
+    }
+  },
+  async getChapters(titleId: string, url: string): Promise<ChaptersResult> {
+    try {
+      logger.log('info', 'Récupération des chapitres depuis MangaDex', { titleId, url });
+      const chaptersUrl = `${mangadexSource.baseUrl}/manga/${titleId}/feed?translatedLanguage[]=fr&translatedLanguage[]=en&order[chapter]=desc&limit=500`;
+      const response = await retry(() => fetch(chaptersUrl), 3, 1000);
+      const data: MangaDexChaptersResponse = await response.json();
+      if (!response.ok || !data.data?.length) {
+        throw new Error('Aucun chapitre trouvé');
+      }
+      const chapters: ChapterData[] = data.data.map((chapter: MangaDexChapter) => ({
+        id: chapter.id,
+        chapter: `Chapitre ${chapter.attributes.chapter || 'inconnu'}`,
+        title: chapter.attributes.title || null,
+        publishedAt: chapter.attributes.publishAt || null,
+        url: `https://mangadex.org/chapter/${chapter.id}`,
+        source: 'mangadex',
+        language: chapter.attributes.translatedLanguage
+      }));
+      logger.log('info', 'Chapitres récupérés avec succès', {
+        chaptersCount: chapters.length,
+        firstChapter: chapters[0],
+        lastChapter: chapters[chapters.length - 1]
+      });
+      return {
+        chapters,
+        totalChapters: chapters.length,
+        source: {
+          name: 'mangadx',
+          url,
+          titleId
+        }
+      };
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la récupération des chapitres sur MangaDex', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
+        titleId
+      });
+      throw error;
+    }
+  }
+};
+
+export default mangadexSource;

--- a/app/services/sources/webtoons.ts
+++ b/app/services/sources/webtoons.ts
@@ -1,0 +1,187 @@
+import { Source, ChaptersResult, ChapterData } from '@/app/types/source';
+import { launchBrowser } from '@/app/utils/launchBrowser';
+import { logger } from '@/app/utils/logger';
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+let browserPromise: Promise<any> | null = null;
+async function getBrowser(): Promise<any> {
+  if (!browserPromise) {
+    browserPromise = launchBrowser({
+      headless: false,
+      args: [
+        '--disable-accelerated-2d-canvas',
+        '--disable-gpu',
+        '--window-size=1920x1080',
+        '--disable-features=IsolateOrigins,site-per-process',
+        '--disable-blink-features=AutomationControlled'
+      ],
+      defaultViewport: null
+    });
+  }
+  return browserPromise;
+}
+
+export const webtoonsSource: Source = {
+  name: 'webtoons',
+  baseUrl: 'https://www.webtoons.com',
+  async search(title: string) {
+    try {
+      const browser = await getBrowser();
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1920, height: 1080 });
+      await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');
+
+      const searchUrl = `${webtoonsSource.baseUrl}/fr/search?keyword=${encodeURIComponent(title)}`;
+      logger.log('info', 'Recherche sur Webtoons', { query: title });
+
+      await page.goto(searchUrl, { waitUntil: 'networkidle0' });
+      await sleep(5000);
+
+      await page.waitForFunction(() => {
+        return document.querySelector('.card_item') !== null ||
+               document.querySelector('.search_result') !== null;
+      }, { timeout: 10000 });
+
+      const result = await page.evaluate((query: string) => {
+        const cards = document.querySelectorAll('.card_item');
+        let bestMatch: { titleId: string; url: string; score: number } | null = null;
+        let bestScore = 0;
+
+        for (const card of Array.from(cards)) {
+          const titleEl = card.querySelector('.subj');
+          const link = card.querySelector('a');
+          if (titleEl && link) {
+            const title = titleEl.textContent?.toLowerCase() || '';
+            const href = link.getAttribute('href') || '';
+            const match = href.match(/title_no=(\d+)/);
+
+            if (match) {
+              const words1 = query.toLowerCase().split(' ');
+              const words2 = title.split(' ');
+              const commonWords = words1.filter(w => words2.includes(w));
+              const score = commonWords.length / Math.max(words1.length, words2.length);
+
+              if (score > bestScore) {
+                bestScore = score;
+                bestMatch = { titleId: match[1], url: href, score };
+              }
+            }
+          }
+        }
+
+        return bestMatch;
+      }, title);
+
+      await page.close();
+
+      if (result && result.score > 0.3) {
+        logger.log('info', 'Manga trouvé sur Webtoons', { query: title });
+        return { titleId: result.titleId, url: result.url };
+      }
+
+      logger.log('info', 'Manga non trouvé sur Webtoons', { query: title });
+      return { titleId: null, url: null };
+
+    } catch (error) {
+      logger.log('error', 'Erreur lors de la recherche sur Webtoons', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue'
+      });
+      return { titleId: null, url: null };
+    }
+  },
+  async getChapters(titleId: string, url: string): Promise<ChaptersResult> {
+    try {
+      const browser = await getBrowser();
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1920, height: 1080 });
+      await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');
+
+      const baseUrl = new URL(url);
+      const listUrl = `${baseUrl.origin}${baseUrl.pathname.split('/episode-')[0]}/list?title_no=${titleId}`;
+      logger.log('info', 'Chargement de la liste des chapitres', { url: listUrl });
+
+      await page.goto(listUrl, { waitUntil: 'networkidle0' });
+      await sleep(2000);
+
+      await page.waitForSelector('#_listUl li', { timeout: 10000 });
+
+      const totalPages = await page.evaluate(() => {
+        const pageElements = document.querySelectorAll('.paginate a');
+        const pages = Array.from(pageElements)
+          .map(el => parseInt(el.textContent || '0'))
+          .filter(num => !isNaN(num));
+        return pages.length > 0 ? Math.max(...pages) : 1;
+      });
+
+      logger.log('info', 'Pages trouvées', { totalPages });
+
+      const allChapters: ChapterData[] = [];
+
+      for (let currentPage = 1; currentPage <= totalPages; currentPage++) {
+        const pageUrl = `${listUrl}&page=${currentPage}`;
+        logger.log('info', 'Chargement de la page', { page: currentPage, totalPages });
+
+        await page.goto(pageUrl, { waitUntil: 'networkidle0' });
+        await sleep(2000);
+
+        await page.waitForSelector('#_listUl li', { timeout: 10000 });
+
+        const chaptersOnPage = await page.evaluate(() => {
+          const items = document.querySelectorAll('#_listUl li');
+          return Array.from(items).map(item => {
+            const link = item.querySelector('a');
+            const titleElement = item.querySelector('.subj');
+            const dateElement = item.querySelector('.date');
+            const href = link?.getAttribute('href') || '';
+            const episodeMatch = href.match(/episode-(\d+)/);
+            const episodeNumber = episodeMatch ? episodeMatch[1] : '';
+            const idMatch = href.match(/episode_no=(\d+)/);
+            const id = idMatch ? idMatch[1] : episodeNumber;
+            const fullTitle = titleElement?.textContent?.trim() || '';
+            const titleMatch = fullTitle.match(/Episode\s+\d+(?:\s*-\s*(.+))?/);
+            const title = titleMatch?.[1]?.trim() || '';
+
+            return {
+              id,
+              chapter: `Episode ${episodeNumber}`,
+              title: title || null,
+              publishedAt: dateElement?.textContent?.trim() || null,
+              url: href,
+              source: 'webtoons'
+            } as ChapterData;
+          });
+        });
+
+        allChapters.push(...chaptersOnPage);
+        logger.log('info', 'Chapitres trouvés sur la page', {
+          page: currentPage,
+          count: chaptersOnPage.length
+        });
+      }
+
+      await page.close();
+      logger.log('info', 'Total des chapitres trouvés', { count: allChapters.length });
+
+      return {
+        chapters: allChapters.reverse(),
+        totalChapters: allChapters.length,
+        source: {
+          name: 'webtoons',
+          url: listUrl,
+          titleId
+        }
+      };
+
+    } catch (error) {
+      logger.log('error', 'Erreur lors du scraping des chapitres sur Webtoons', {
+        error: error instanceof Error ? error.message : 'Erreur inconnue'
+      });
+      throw error;
+    }
+  }
+};
+
+export default webtoonsSource;


### PR DESCRIPTION
## Summary
- modularize source handlers under `app/services/sources`
- streamline chapters API route to focus on request handling
- document new modular structure in README

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm audit`
- `npx vitest run` *(fails: some tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_684862ff78d08326b5104d5db14d3037