### PR TITLE
fix(chapter-api): await cache write and log errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - The `Strict-Transport-Security` header enforces HTTPS for two years across all subdomains.
 - MangaDex API requests automatically retry up to three times on network errors.
 - In-memory cache automatically prunes expired entries to limit memory usage.
+- Cache writes are awaited and errors are logged for easier debugging.
  - Multi-source search aggregates MangaDex, Kitsu and Komga before falling back to scraping.
  - Chapters are fetched concurrently from MangaDex, Webtoons and Komga, returning the fastest result.
 - Connection pooling via `undici` enables HTTP/2 requests with configurable concurrency.

--- a/app/api/manga/[id]/chapter/[chapterId]/route.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route.ts
@@ -588,7 +588,14 @@ async function handleGet(
     };
 
     // Mettre en cache pour 1 heure
-    cache.set(cacheKey, result);
+    try {
+      await cache.set(cacheKey, result);
+    } catch (error) {
+      logger.log('error', 'chapter cache set error', {
+        error: String(error),
+        cacheKey,
+      });
+    }
 
     console.log(`✅ Scraping terminé: ${images.length} images trouvées`);
     return NextResponse.json(result);


### PR DESCRIPTION
## Summary
- await caching in chapter API route
- log caching errors when storing chapter result
- document the caching behaviour

## Testing
- `npm run lint`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684862d50b8483269c110e325d1fc7aa