### PR TITLE
Replace console statements with logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Asynchronous API routes with proper parameter handling.
 - Timestamped error logs for easier debugging.
 - Consistent `logger.log('error')` calls replace `console.error` for structured logging.
+- `console.log` and `console.warn` are replaced with `logger.log` for unified structured logs.
 - Unified API response with `pageCount` and `pages` array.
 - Stronger type safety with explicit interfaces replacing `any`.
 - Extended MangaDex type definitions for `lastChapter` and `contentRating`.

--- a/app/api/manga/[id]/chapter/[chapterId]/route.ts
+++ b/app/api/manga/[id]/chapter/[chapterId]/route.ts
@@ -43,9 +43,10 @@ async function getMangaDexChapterImages(
       RETRY_DELAY,
     );
     if (!res.ok) {
-      console.log(
-        `${new Date().toISOString()} ⚠️ MangaDex at-home failed: ${res.status}`,
-      );
+      logger.log('warning', 'MangaDex at-home failed', {
+        status: res.status,
+        chapterId
+      });
       return [];
     }
     const data = await res.json();
@@ -217,7 +218,7 @@ async function performLazyLoad(
   lazyConfig?: ScrapingConfig['selectors']['lazyLoad']
 ): Promise<void> {
   if (!lazyConfig) {
-    console.log('⚠️ Aucune configuration de lazy load fournie');
+    logger.log('warning', 'no lazy load configuration provided');
     return Promise.resolve();
   }
   
@@ -261,15 +262,15 @@ async function scrapeImagesRobust(
   config: ScrapingConfig
 ): Promise<string[]> {
   const images = new Map<string, number>();
-  console.log(`📝 Début du scraping robuste avec la configuration ${config.name}`);
+  logger.log('info', 'robust scraping started', { config: config.name });
 
   try {
     // Attendre le chargement initial avec timeout réduit
     try {
       await page.waitForSelector('img, canvas, [style*="background-image"]', { timeout: 10000 });
-      console.log('✅ Page chargée, éléments visuels détectés');
+      logger.log('info', 'page loaded, visual elements detected');
     } catch {
-      console.log('⚠️ Timeout sur les éléments visuels, continuation...');
+      logger.log('warning', 'timeout on visual elements, continuing');
       return [];
     }
 
@@ -295,7 +296,7 @@ async function scrapeImagesRobust(
 
     if (config.name === 'webtoons') {
       // Méthode spécifique pour Webtoons
-      console.log('🔄 Scraping des images Webtoons');
+      logger.log('info', 'scraping webtoons images');
 
       // Attendre que les images soient chargées
       await page.waitForSelector('img[data-url]', { timeout: 10000 });
@@ -314,7 +315,7 @@ async function scrapeImagesRobust(
 
     } else {
       // Méthode générique pour les autres sites
-      console.log('🔄 Scroll progressif');
+      logger.log('info', 'progressive scroll started');
       await performLazyLoad(page, config.selectors.lazyLoad);
 
       const currentUrls = await page.evaluate((selectors: string[]) => {
@@ -338,10 +339,10 @@ async function scrapeImagesRobust(
         }
       });
 
-      console.log(`📊 Images récupérées: ${images.size}`);
+      logger.log('info', 'images collected', { count: images.size });
 
       // Scroll progressif pour charger le contenu lazy
-      console.log('🔄 Scroll pour charger le contenu...');
+      logger.log('info', 'scrolling to load content');
       const scrollSteps = config.selectors.lazyLoad?.maxScrolls || 20;
       const stepSize = config.selectors.lazyLoad?.scrollStep || 500;
 
@@ -362,7 +363,11 @@ async function scrapeImagesRobust(
         );
         
         if (i % 5 === 0) {
-          console.log(`📸 Scroll ${i}/${scrollSteps}: ${currentImageCount} images détectées`);
+          logger.log('info', 'scroll progress', {
+            step: i,
+            total: scrollSteps,
+            images: currentImageCount
+          });
         }
       }
 
@@ -396,10 +401,16 @@ async function scrapeImagesRobust(
           });
 
           if (imgSrcs.length > 0) {
-            console.log(`✅ ${imgSrcs.length} images trouvées avec ${selector}`);
+            logger.log('info', 'images found with selector', {
+              selector,
+              count: imgSrcs.length
+            });
           }
         } catch (error) {
-          console.log(`⚠️ Erreur avec le sélecteur ${selector}: ${error}`);
+          logger.log('warning', 'selector error', {
+            selector,
+            error: String(error)
+          });
         }
       }
       
@@ -407,7 +418,7 @@ async function scrapeImagesRobust(
     
     // Si on arrive ici, on a terminé le traitement
     if (images.size === 0) {
-      console.log('⚠️ Aucune image trouvée avec les sélecteurs standards');
+      logger.log('warning', 'no images found with standard selectors');
       return [];
     }
     
@@ -433,11 +444,11 @@ async function handleGet(
     // Vérifier le cache
     const cached = await cache.get(cacheKey);
     if (cached) {
-      console.log('📦 Données du chapitre récupérées du cache');
+      logger.log('info', 'chapter data retrieved from cache', { chapterId, mangaId });
       return NextResponse.json(cached);
     }
 
-    console.log(`🔍 Lecture du chapitre ${chapterId}`);
+    logger.log('info', 'reading chapter', { chapterId });
 
     // Récupérer les infos du manga depuis l'API MangaDex
     const mangaResponse = await retry(
@@ -473,7 +484,9 @@ async function handleGet(
     const chapterData = await chapterResponse.json();
     const chapter = chapterData.data;
     
-    console.log(`📚 Langue du chapitre: ${chapter.attributes.translatedLanguage}`);
+    logger.log('info', 'chapter language detected', {
+      language: chapter.attributes.translatedLanguage
+    });
 
     const language = chapter.attributes.translatedLanguage;
     const configs = SCRAPING_CONFIGS[language] || SCRAPING_CONFIGS['en'];
@@ -482,7 +495,9 @@ async function handleGet(
     let successfulConfig: string | null = images.length > 0 ? 'mangadex-direct' : null;
 
     if (images.length > 0) {
-      console.log(`✅ ${images.length} images récupérées via MangaDex`);
+      logger.log('info', 'images retrieved via MangaDex', {
+        count: images.length
+      });
     }
 
     // Obtenir le titre en slug format
@@ -495,7 +510,10 @@ async function handleGet(
       for (const config of configs) {
         try {
           const url = config.urlPattern(slug, chapterNumber, manga.attributes.title.en);
-          console.log(`🌐 Fallback avec ${config.name}: ${url}`);
+          logger.log('info', 'fallback attempt', {
+            config: config.name,
+            url
+          });
 
           const browser = await getBrowser();
           const page = await browser.newPage();
@@ -512,23 +530,27 @@ async function handleGet(
 
             if (images.length > 0) {
               successfulConfig = config.name;
-              console.log(
-                `✅ ${images.length} images récupérées avec ${config.name}`,
-              );
+              logger.log('info', 'images retrieved with config', {
+                config: config.name,
+                count: images.length
+              });
               break;
             }
           } finally {
             await page.close();
           }
         } catch (error) {
-          console.log(`❌ Erreur avec ${config.name}: ${error}`);
+          logger.log('warning', 'scraping config error', {
+            config: config.name,
+            error: String(error)
+          });
         }
       }
     }
 
     // Fallback avec images de démonstration si aucune image trouvée
     if (images.length === 0) {
-      console.log('⚠️ Aucune image trouvée, utilisation d\'images de démonstration');
+      logger.log('warning', 'no images found, using demo images');
       // Utiliser des images SVG générées directement pour éviter les problèmes de CORS
       const generateDemoImage = (pageNum: number) => {
         const svgContent = `
@@ -566,7 +588,7 @@ async function handleGet(
       }
     } catch (error) {
       // Ignorer les erreurs de récupération de la couverture
-      console.log('⚠️ Impossible de récupérer la couverture du manga');
+      logger.log('warning', 'unable to retrieve manga cover');
     }
 
     const result: ChapterResult = {
@@ -590,7 +612,10 @@ async function handleGet(
     // Mettre en cache pour 1 heure
     cache.set(cacheKey, result);
 
-    console.log(`✅ Scraping terminé: ${images.length} images trouvées`);
+    logger.log('info', 'scraping finished', {
+      images: images.length,
+      chapterId
+    });
     return NextResponse.json(result);
   } catch (error) {
     logger.log('error', 'chapter retrieval error', {

--- a/app/api/scraping-test/route.ts
+++ b/app/api/scraping-test/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
       ]
     };
 
-    console.log(`🔍 Test de diagnostic pour: ${url}`);
+    logger.log('info', 'diagnostic test for URL', { url });
     const result = await diagnoseScrapingSelectors(url, defaultSelectors);
 
     // Simplifier le résultat pour l'API

--- a/app/components/ChapterReader.tsx
+++ b/app/components/ChapterReader.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import Image from 'next/image'
 import { ChevronUp } from 'lucide-react'
 import ImageErrorFeedback from './ImageErrorFeedback'
+import { logger } from '../utils/logger'
 
 interface ChapterReaderProps {
   pages: string[]
@@ -107,7 +108,7 @@ const ChapterReader: React.FC<ChapterReaderProps> = ({ pages, chapter, mangaTitl
 
   const handleReportImage = (pageIndex: number) => {
     // Optionnel : envoyer le rapport à un service de feedback
-    console.log(`Image signalée pour la page ${pageIndex + 1}`)
+    logger.log('info', 'image reported', { index: pageIndex + 1 })
   }
 
   // Initial preload

--- a/app/components/ModernRecommendationsSection.tsx
+++ b/app/components/ModernRecommendationsSection.tsx
@@ -7,6 +7,7 @@ import { BookOpen, Sparkles, Target } from 'lucide-react';
 import { useFavorites } from '../hooks/useFavorites';
 import { useRecommendations } from '../hooks/useRecommendations';
 import { Manga } from '../types/manga';
+import { logger } from '../utils/logger';
 
 interface ModernRecommendationsSectionProps {
   onSearch: (query: string) => void;
@@ -20,13 +21,15 @@ export default function ModernRecommendationsSection({ onSearch }: ModernRecomme
   const { favorites } = useFavorites();
   const [mounted, setMounted] = useState(false);
 
-  // Debug console logs
+  // Debug logs
   useEffect(() => {
-    console.log('🎯 ModernRecommendationsSection mounted');
-    console.log('📚 Recommendations:', recommendations);
-    console.log('⏳ Loading:', loading);
-    console.log('❌ Error:', error);
-    console.log('💖 Favorites count:', favorites.length);
+    logger.log('info', 'ModernRecommendationsSection mounted');
+    logger.log('info', 'recommendations state updated', {
+      count: recommendations.length,
+      loading,
+      error
+    });
+    logger.log('info', 'favorites count', { count: favorites.length });
     setMounted(true);
   }, [recommendations, loading, error, favorites.length]);
 
@@ -35,7 +38,7 @@ export default function ModernRecommendationsSection({ onSearch }: ModernRecomme
     const handleKeydown = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.key === 'R') {
         e.preventDefault();
-        console.log('🔄 Rechargement forcé des recommandations...');
+        logger.log('info', 'forcing recommendations reload');
         refetch();
       }
     };
@@ -45,15 +48,17 @@ export default function ModernRecommendationsSection({ onSearch }: ModernRecomme
   }, [refetch]);
 
   if (!mounted) {
-    console.log('⏸️ Component not mounted yet');
+    logger.log('info', 'component not mounted yet');
     return null;
   }
   
-  console.log('🎨 Rendering recommendations section, items:', recommendations.length);
+  logger.log('info', 'rendering recommendations section', {
+    items: recommendations.length
+  });
   
   // Show a loading state rather than nothing
   if (loading) {
-    console.log('⏳ Affichage du state de chargement...');
+    logger.log('info', 'displaying loading state');
     return (
       <section className="mt-8 mb-6">
         <div className="flex items-center justify-between mb-4">
@@ -85,7 +90,7 @@ export default function ModernRecommendationsSection({ onSearch }: ModernRecomme
 
   // If there's an error, show it and allow retry
   if (error) {
-    console.log('❌ Affichage de l\'erreur:', error);
+    logger.log('error', 'displaying error', { error });
     return (
       <section className="mt-8 mb-6">
         <div className="flex items-center justify-between mb-4">
@@ -118,7 +123,7 @@ export default function ModernRecommendationsSection({ onSearch }: ModernRecomme
 
   // If there are actually no recommendations after loading, show a message
   if (!recommendations.length) {
-    console.log('📭 Aucune recommandation trouvée');
+    logger.log('info', 'no recommendations found');
     return (
       <section className="mt-8 mb-6">
         <div className="flex items-center justify-between mb-4">
@@ -149,7 +154,9 @@ export default function ModernRecommendationsSection({ onSearch }: ModernRecomme
     );
   }
 
-  console.log('✅ Affichage des recommandations:', recommendations.map(r => r.title));
+  logger.log('info', 'displaying recommendations', {
+    titles: recommendations.map(r => r.title)
+  });
 
   return (
     <section className="mt-8 mb-6">

--- a/app/hooks/useFavorites.tsx
+++ b/app/hooks/useFavorites.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, createContext, useContext, ReactNode, use } from 'react';
 import { Manga, FavoriteManga, ReadingStatus } from '../types/manga';
+import { logger } from '../utils/logger';
 
 const FAVORITES_KEY = 'mangaScraper_favorites';
 
@@ -30,10 +31,14 @@ function useFavoritesState(): FavoritesContextType {
       try {
         const saved = localStorage.getItem(FAVORITES_KEY);
         const parsedFavorites = saved ? JSON.parse(saved) : [];
-        console.log('Loading favorites from localStorage:', { saved, count: parsedFavorites.length });
+        logger.log('info', 'favorites loaded from localStorage', {
+          count: parsedFavorites.length
+        });
         setFavorites(parsedFavorites);
       } catch (error) {
-        console.error('Failed to load favorites from localStorage:', error);
+        logger.log('error', 'failed to load favorites from localStorage', {
+          error: String(error)
+        });
         setFavorites([]);
       } finally {
         setIsLoaded(true);
@@ -44,10 +49,14 @@ function useFavoritesState(): FavoritesContextType {
   useEffect(() => {
     if (typeof window !== 'undefined' && isLoaded) {
       try {
-        console.log('Saving favorites to localStorage:', { count: favorites.length });
+        logger.log('info', 'favorites saved to localStorage', {
+          count: favorites.length
+        });
         localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
       } catch (error) {
-        console.error('Failed to save favorites to localStorage:', error);
+        logger.log('error', 'failed to save favorites to localStorage', {
+          error: String(error)
+        });
       }
     }
   }, [favorites, isLoaded]);
@@ -63,7 +72,9 @@ function useFavoritesState(): FavoritesContextType {
         chapterCount: manga.chapterCount || { french: 0, total: 0 }
       };
       
-      console.log('Adding manga to favorites:', { manga: newFavorite });
+      logger.log('info', 'manga added to favorites', {
+        mangaId: newFavorite.id
+      });
       return [...prev, newFavorite];
     });
   };
@@ -71,7 +82,10 @@ function useFavoritesState(): FavoritesContextType {
   const removeFromFavorites = (mangaId: string) => {
     setFavorites(prev => {
       const filtered = prev.filter(manga => manga.id !== mangaId);
-      console.log('Removing manga from favorites:', { mangaId, count: filtered.length });
+      logger.log('info', 'manga removed from favorites', {
+        mangaId,
+        remaining: filtered.length
+      });
       return filtered;
     });
   };

--- a/app/utils/hydration-diagnostics.ts
+++ b/app/utils/hydration-diagnostics.ts
@@ -3,6 +3,8 @@
  * Utilisé pour identifier et déboguer les différences entre serveur et client
  */
 
+import { logger } from './logger';
+
 export const hydrationDiagnostics = {
   /**
    * Log les différences d'attributs HTML qui peuvent causer des problèmes d'hydratation
@@ -13,11 +15,11 @@ export const hydrationDiagnostics = {
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === 'attributes') {
-          console.warn('Hydration: Attribut modifié après hydratation:', {
-            element: mutation.target,
-            attribute: mutation.attributeName,
-            oldValue: mutation.oldValue,
-            newValue: (mutation.target as Element).getAttribute(mutation.attributeName || '')
+          logger.log('warning', 'hydration attribute changed', {
+            element: mutation.target as Element,
+            attribute: mutation.attributeName ?? undefined,
+            oldValue: mutation.oldValue ?? undefined,
+            newValue: (mutation.target as Element).getAttribute(mutation.attributeName || '') ?? undefined
           });
         }
       });
@@ -51,7 +53,9 @@ export const hydrationDiagnostics = {
     );
 
     if (foundAttributes.length > 0) {
-      console.warn('Hydration: Extensions détectées:', foundAttributes);
+      logger.log('warning', 'browser extensions detected', {
+        extensions: foundAttributes
+      });
     }
 
     return foundAttributes;
@@ -67,7 +71,9 @@ export const hydrationDiagnostics = {
     const timeElements = document.querySelectorAll('[data-time], [data-timestamp]');
     
     if (timeElements.length > 0) {
-      console.warn('Hydration: Éléments temporels détectés:', timeElements);
+      logger.log('warning', 'time-based elements detected', {
+        elements: Array.from(timeElements).map(el => el.outerHTML?.slice(0, 50))
+      });
     }
   }
 };

--- a/app/utils/redisClient.ts
+++ b/app/utils/redisClient.ts
@@ -19,7 +19,7 @@ export async function getRedisClient(): Promise<RedisClientType> {
     });
     
     client.on('connect', () => {
-      console.log('Redis connected successfully');
+      logger.log('info', 'redis connected successfully');
     });
     
     await client.connect();
@@ -32,7 +32,7 @@ export async function testRedisConnection(): Promise<boolean> {
   try {
     const redis = await getRedisClient();
     await redis.ping();
-    console.log('Redis connection test: SUCCESS');
+    logger.log('info', 'redis connection test success');
     return true;
   } catch (error) {
     logger.log('error', 'Redis connection test failed', { error: String(error) });

--- a/app/utils/scraping-diagnostics.ts
+++ b/app/utils/scraping-diagnostics.ts
@@ -45,7 +45,7 @@ export async function diagnoseScrapingSelectors(
   };
 
   try {
-    console.log(`🔍 Diagnostic de ${testUrl}`);
+    logger.log('info', 'diagnosing scraping selectors', { url: testUrl });
     
     // Configuration de la page
     await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');


### PR DESCRIPTION
## Summary
- use `logger.log` instead of `console.log`, `console.warn` and `console.error`
- document the unified logging approach

## Testing
- `npm run lint`
- `npx vitest --run`
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684862d40b6883269a78f405abbbabb0