### PR TITLE
Fix source handlers and add caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Chapters are fetched concurrently from MangaDex, Webtoons and Komga, returning the fastest result.
 - Source handlers live under `app/services/sources` for easier maintenance.
 - Cache writes are awaited and errors are logged for easier debugging.
+- Search results from MangaDex and Webtoons are cached for an hour to reduce network calls.
  - Multi-source search aggregates MangaDex, Kitsu and Komga before falling back to scraping.
  - Chapters are fetched concurrently from MangaDex, Webtoons and Komga, returning the fastest result.
 - Connection pooling via `undici` enables HTTP/2 requests with configurable concurrency.


### PR DESCRIPTION
## Summary
- remove duplicate code from MangaDex and Webtoons sources
- enforce HTTPS and cache search results
- document search caching in README

## Testing
- `npx eslint app/services/sources/mangadex.ts app/services/sources/webtoons.ts`
- `npm run lint` *(fails: many existing lint errors)*
- `npx vitest run` *(fails: tests in `useRecommendations.test.tsx`)*
- `npm audit --omit=dev`

------
https://chatgpt.com/codex/tasks/task_e_6849405577a48326a2b531f7d9e438a7